### PR TITLE
chore: prettierフォーマッタの設定ファイルを追加

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+# .prettierrc.yaml
+endOfLine: lf
+trailingComma: "es5"
+tabWidth: 2
+semi: false
+singleQuote: true


### PR DESCRIPTION
Nuxtプロジェクト配下に `.editorconfig` ファイルがあるため、VS Codeによる設定が無視される。
このため設定ファイルを追加した。