### PR TITLE
chore: add a prettier setting (#16)

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+# .prettierrc.yaml
+endOfLine: lf
+trailingComma: "es5"
+tabWidth: 2
+semi: false
+singleQuote: true


### PR DESCRIPTION
Prettier ignore the vscode setting.
Because nuxt project include .editorconfig file.