### PR TITLE
Revert "chore: 自動テスト対象のファイル指定 (#44)"

### DIFF
--- a/.github/workflows/testing_pull_request.yml
+++ b/.github/workflows/testing_pull_request.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - master
       - develop
-    paths:
-      - '**.js'
-      - '**.ts'
-      - '**.vue'
-      - '.github/workflows/*.yml'
 
 jobs:
   testing:


### PR DESCRIPTION
`.github/workflows/testing_pull_request.yml` のみ戻す。

Githubのプルリクエスト・マージにおいて必須ステータスチェックとして利用するには、
プルリクエスト作成時に必ず実行する必要があるためファイル制限を削除。