### PR TITLE
fix: LinkWrapperコンポーネントのpropを修正

### DIFF
--- a/src/components/atoms/LinkWrapper.spec.ts
+++ b/src/components/atoms/LinkWrapper.spec.ts
@@ -2,9 +2,9 @@ import { shallowMount, Wrapper, RouterLinkStub } from '@vue/test-utils'
 import LinkWrapper from './LinkWrapper.vue'
 
 describe('LinkWrapper', () => {
-  const createWrapper = (prop: { url: string }) => {
+  const createWrapper = (href: string) => {
     return shallowMount(LinkWrapper, {
-      propsData: { link: prop },
+      propsData: { href: href },
       stubs: { NuxtLink: RouterLinkStub },
       slots: {
         default: 'hoge',
@@ -14,11 +14,9 @@ describe('LinkWrapper', () => {
 
   test('is inner link or outer link', () => {
     let url = 'https://example.com'
-    expect(
-      createWrapper({ url: url }).find('a[href]').attributes()['href']
-    ).toBe(url)
+    expect(createWrapper(url).find('a[href]').attributes()['href']).toBe(url)
 
     url = '/sample/inner'
-    expect(createWrapper({ url: url }).props().to).toBe(url)
+    expect(createWrapper(url).props().to).toBe(url)
   })
 })

--- a/src/components/atoms/LinkWrapper.vue
+++ b/src/components/atoms/LinkWrapper.vue
@@ -1,8 +1,8 @@
 <template functional>
   <a
     class="text-indigo-500 visited:text-purple-800 hover:underline"
-    v-if="props.link.url.match(/^https?:\/\//) != null"
-    v-bind:href="props.link.url"
+    v-if="props.href.match(/^https?:\/\//) != null"
+    v-bind:href="props.href"
     target="_blank"
   >
     <slot></slot>
@@ -10,7 +10,7 @@
   <nuxt-link
     class="text-indigo-500 visited:text-purple-800 hover:underline"
     v-else
-    v-bind:to="props.link.url"
+    v-bind:to="props.href"
   >
     <slot></slot>
   </nuxt-link>
@@ -25,13 +25,10 @@ import { Component, Prop, Vue } from 'nuxt-property-decorator'
 @Component
 export default class LinkWrapper extends Vue {
   /**
-   * 内部リンク先のURLを格納。
-   *
-   * `:` が混ざると直接 `v-bind` 属性の値として入力できないため、オブジェクトでラップする。
+   * リンク先のURLを格納。
    */
-  @Prop({ required: true }) link!: { url: string }
+  @Prop({ required: true }) href!: string
 }
 </script>
 
-<style>
-</style>
+<style></style>

--- a/src/pages/license/index.vue
+++ b/src/pages/license/index.vue
@@ -5,9 +5,9 @@
         <ul class="list-disc ml-6">
           <li class="mt-8">
             Material Design icons: Licensed under
-            <LinkWrapper
-              v-bind:link="{url: 'https://www.apache.org/licenses/LICENSE-2.0'}"
-            >Apache license version 2.0</LinkWrapper>.
+            <LinkWrapper href="https://www.apache.org/licenses/LICENSE-2.0"
+              >Apache license version 2.0</LinkWrapper
+            >.
           </li>
         </ul>
       </template>


### PR DESCRIPTION
Javascript式が不要ならば `v-bind` も不要なため、`:` のある文字列も使用できる。
よってわざわざオブジェクトを受け取る必要がないので簡略化した。