### PR TITLE
feat: トップページの作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "nuxt-ts build",
     "deploy": "yarn license-file && yarn mdlist && env DEPLOY_ENV=GH_PAGES NODE_ENV=production nuxt-ts generate",
-    "dev": "yarn mdlist && nuxt-ts",
+    "dev": "nuxt-ts",
     "fmt": "yarn prettier --config .prettierrc.yml --write '**/*.{js,ts,vue,json}'",
     "generate": "NODE_ENV=production nuxt-ts generate",
     "license-file": "yarn licenses generate-disclaimer --ignore-platform > src/assets/thirdparty_license.txt",

--- a/src/components/atoms/ButtonPagination.spec.ts
+++ b/src/components/atoms/ButtonPagination.spec.ts
@@ -1,0 +1,47 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import ButtonPagination from './ButtonPagination.vue'
+
+describe('ButtonPagination', () => {
+  const createWrapper = (prop: {
+    isDisabled: boolean
+    page?: number
+    icon?: string
+  }) =>
+    shallowMount(ButtonPagination, {
+      propsData: {
+        property: prop,
+      },
+    })
+
+  test('is button or icon', () => {
+    let wrapper = createWrapper({ isDisabled: false, page: 4 })
+    expect(wrapper.contains('.pagination-btn')).toBeTruthy()
+    expect(wrapper.contains('.pagination-icon')).toBeFalsy()
+
+    wrapper = createWrapper({ isDisabled: false, icon: 'done' })
+    expect(wrapper.contains('.pagination-btn')).toBeFalsy()
+    expect(wrapper.contains('.pagination-icon')).toBeTruthy()
+
+    wrapper = createWrapper({ isDisabled: false })
+    expect(wrapper.contains('.pagination-btn')).toBeTruthy()
+    expect(wrapper.contains('.pagination-icon')).toBeFalsy()
+
+    wrapper = createWrapper({ isDisabled: false, page: 4, icon: 'done' })
+    expect(wrapper.contains('.pagination-btn')).toBeFalsy()
+    expect(wrapper.contains('.pagination-icon')).toBeTruthy()
+  })
+
+  test('is disabled', () => {
+    expect(
+      createWrapper({ isDisabled: true, page: 1 }).contains(
+        '.pagination-btn[disabled]'
+      )
+    ).toBeTruthy()
+
+    expect(
+      createWrapper({ isDisabled: true, icon: 'done' }).contains(
+        '.pagination-icon[disabled]'
+      )
+    ).toBeTruthy()
+  })
+})

--- a/src/components/atoms/ButtonPagination.vue
+++ b/src/components/atoms/ButtonPagination.vue
@@ -1,0 +1,68 @@
+<template functional>
+  <button
+    v-if="props.property.icon == null"
+    class="mdc-button pagination-btn"
+    v-bind:class="[data.class, data.staticClass]"
+    v-bind:disabled="props.property.isDisabled"
+  >
+    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__label">{{ props.property.page }}</span>
+  </button>
+  <button
+    v-else
+    class="mdc-icon-button material-icons pagination-icon"
+    v-bind:disabled="props.property.isDisabled"
+  >{{ props.property.icon }}</button>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+/**
+ * ページネーション用に調整したボタンを提供するコンポーネント。
+ */
+@Component
+export default class ButtonPagination extends Vue {
+  @Prop() property!: {
+    /**
+     * `true` の場合に `disabled` 属性をつける。
+     */
+    isDisabled: boolean
+
+    /**
+     * ページ番号
+     */
+    page?: number
+
+    /**
+     * Materialアイコン名。
+     * Material Icons(https://material.io/resources/icons) の利用を前提とする。
+     */
+    icon?: string
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@use 'material_theme.scss' as theme;
+@use '@material/button/mdc-button';
+@use '@material/button';
+@use "@material/icon-button" as icon;
+
+.pagination-btn {
+  @include button.ink-color(rgba(0, 0, 0, 0.87));
+  @include button.disabled-ink-color(rgba(0, 0, 0, 0.54));
+  min-width: 40px;
+  --mdc-typography-button-font-size: 1.25rem;
+
+  &[disabled] {
+    background: #bdbdbd;
+  }
+}
+
+.pagination-icon {
+  @include icon.icon-size(32px, 32px, 4px);
+  @include icon.ink-color(rgba(0, 0, 0, 0.87));
+  @include icon.disabled-ink-color(rgba(0, 0, 0, 0.38));
+}
+</style>

--- a/src/components/atoms/LinkWrapper.spec.ts
+++ b/src/components/atoms/LinkWrapper.spec.ts
@@ -2,9 +2,9 @@ import { shallowMount, Wrapper, RouterLinkStub } from '@vue/test-utils'
 import LinkWrapper from './LinkWrapper.vue'
 
 describe('LinkWrapper', () => {
-  const createWrapper = (href: string) => {
+  const createWrapper = (href: string, disabled?: boolean) => {
     return shallowMount(LinkWrapper, {
-      propsData: { href: href },
+      propsData: { href: href, disabled: disabled },
       stubs: { NuxtLink: RouterLinkStub },
       slots: {
         default: 'hoge',
@@ -16,7 +16,16 @@ describe('LinkWrapper', () => {
     let url = 'https://example.com'
     expect(createWrapper(url).find('a[href]').attributes()['href']).toBe(url)
 
+    url = 'http://example2.com'
+    expect(createWrapper(url).find('a[href]').attributes()['href']).toBe(url)
+
     url = '/sample/inner'
     expect(createWrapper(url).props().to).toBe(url)
+  })
+
+  test('is disable', () => {
+    const url = 'https://example.com'
+    expect(createWrapper(url).contains('.link[disabled]')).toBeFalsy()
+    expect(createWrapper(url, true).contains('.link[disabled]')).toBeTruthy()
   })
 })

--- a/src/components/atoms/LinkWrapper.vue
+++ b/src/components/atoms/LinkWrapper.vue
@@ -1,16 +1,18 @@
 <template functional>
   <a
-    class="text-indigo-500 visited:text-purple-800 hover:underline"
     v-if="props.href.match(/^https?:\/\//) != null"
+    class="link"
     v-bind:href="props.href"
     target="_blank"
+    v-bind:disabled="props.disabled"
   >
     <slot></slot>
   </a>
   <nuxt-link
-    class="text-indigo-500 visited:text-purple-800 hover:underline"
     v-else
     v-bind:to="props.href"
+    class="link"
+    v-bind:disabled="props.disabled"
   >
     <slot></slot>
   </nuxt-link>
@@ -28,7 +30,26 @@ export default class LinkWrapper extends Vue {
    * リンク先のURLを格納。
    */
   @Prop({ required: true }) href!: string
+
+  @Prop() disabled!: boolean
 }
 </script>
 
-<style></style>
+<style lang="scss" scoped>
+.link:not([disabled]) {
+  @apply text-indigo-500;
+
+  &:visited {
+    @apply text-purple-800;
+  }
+
+  &:hover {
+    @apply underline;
+  }
+}
+
+.link[disabled] {
+  /* リンクを無効化 */
+  pointer-events: none;
+}
+</style>

--- a/src/components/molecules/LinkButtonPagination.spec.ts
+++ b/src/components/molecules/LinkButtonPagination.spec.ts
@@ -1,0 +1,51 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import LinkButtonPagination from './LinkButtonPagination.vue'
+import { PagingMode } from '@/models'
+
+describe('LinkButtonPagination', () => {
+  const createWrapper = (href: string, mode: PagingMode, disabled?: boolean) =>
+    shallowMount(LinkButtonPagination, {
+      propsData: {
+        href: href,
+        mode: mode,
+        disabled: disabled,
+      },
+    })
+
+  test('is attributes', () => {
+    const example = 'https://example.com'
+    let wrapper = createWrapper(example, 'first')
+    expect(wrapper.find('[href]').attributes().href).toBe(example)
+    expect(wrapper.contains('[disabled]')).toBeFalsy()
+
+    wrapper = createWrapper(example, { page: '7' })
+    expect(wrapper.find('[href]').attributes().href).toBe(example)
+    expect(wrapper.contains('[disabled]')).toBeFalsy()
+
+    wrapper = createWrapper(example, { page: '7' }, true)
+    expect(wrapper.find('[href]').attributes().href).toBe(example)
+    expect(wrapper.contains('[disabled]')).toBeTruthy()
+  })
+
+  test('of propByPaging', () => {
+    const url = 'http://sample.com'
+
+    expect(createWrapper(url, 'first').find('.pagination-icon').text()).toBe(
+      'first_page'
+    )
+    expect(createWrapper(url, 'prev').find('.pagination-icon').text()).toBe(
+      'chevron_left'
+    )
+
+    expect(createWrapper(url, 'next').find('.pagination-icon').text()).toBe(
+      'chevron_right'
+    )
+
+    expect(
+      createWrapper(url, { page: '7' }).find('.pagination-icon').exists()
+    ).toBeFalsy()
+    expect(
+      createWrapper(url, { page: '7' }).find('.pagination-btn').text()
+    ).toBe('7')
+  })
+})

--- a/src/components/molecules/LinkButtonPagination.vue
+++ b/src/components/molecules/LinkButtonPagination.vue
@@ -1,0 +1,68 @@
+<template functional>
+  <component
+    v-bind:is="injections.components.LinkWrapper"
+    v-bind:href="props.href"
+    v-bind:disabled="props.disabled"
+  >
+    <component
+      v-bind:is="injections.components.ButtonPagination"
+      v-bind:property="{isDisabled: props.disabled, ...$options.methods.propByPaging(props.mode)}"
+    />
+  </component>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import ButtonPagination from '../atoms/ButtonPagination.vue'
+import LinkWrapper from '../atoms/LinkWrapper.vue'
+import { PagingMode } from '../../models'
+import { isObject } from '../../helpers/functions'
+
+@Component({
+  inject: {
+    components: {
+      default: {
+        ButtonPagination,
+        LinkWrapper,
+      },
+    },
+  },
+})
+export default class LinkButtonPagination extends Vue {
+  /**
+   * リンク先URL。
+   */
+  @Prop({ required: true }) href!: string
+
+  /**
+   * ページング操作の種類。
+   */
+  @Prop({ required: true }) mode!: PagingMode
+
+  /**
+   * `true` の場合に `disabled` 属性をつける。
+   */
+  @Prop() disabled?: boolean
+
+  /**
+   * ページング操作ごとのページ番号もしくはMaterialアイコン名を返す。
+   */
+  propByPaging(mode: PagingMode) {
+    if (isObject(mode)) {
+      return mode
+    }
+
+    const iconDict = new Map<PagingMode, string>([
+      ['first', 'first_page'],
+      ['prev', 'chevron_left'],
+      ['next', 'chevron_right'],
+      ['last', 'last_page'],
+    ])
+
+    return { icon: iconDict.get(mode) ?? 'error' }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/components/organisms/OverviewArticle.spec.ts
+++ b/src/components/organisms/OverviewArticle.spec.ts
@@ -1,0 +1,41 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import OverviewArticle from './OverviewArticle.vue'
+import { PostFile } from '@/models'
+
+describe('OverviewArticle', () => {
+  const samplePost: PostFile = {
+    path: 'src/assets/sample.md',
+    filename: 'sample.md',
+    filename_noext: 'sample',
+    title: 'This is sample!',
+    created_at: '2020-06-22',
+    tags: ['test', 'sample', 'hoge'],
+  }
+  const createWrapper = (content: Partial<PostFile>) =>
+    shallowMount(OverviewArticle, {
+      propsData: {
+        content: { ...samplePost, ...content },
+      },
+      stubs: {
+        NuxtLink: true,
+      },
+    })
+
+  test.each([
+    ['2020-06-01', '2020/06/01'],
+    ['2020-05-15', '2020/05/15'],
+    ['2020-10-10', '2020/10/10'],
+  ])('does createdAt(%s)', (x, expected) => {
+    const wrapper = createWrapper({ created_at: x })
+    expect((wrapper.vm as any).createdAt).toEqual(expected)
+  })
+
+  test.each([
+    ['hoge', '/posts/hoge'],
+    ['f o o', '/posts/f+o+o'],
+    ['にほんご', '/posts/%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94'],
+  ])('does linkToArticle(%s)', (x, expected) => {
+    const wrapper = createWrapper({ filename_noext: x })
+    expect((wrapper.vm as any).linkToArticle).toEqual(expected)
+  })
+})

--- a/src/components/organisms/OverviewArticle.vue
+++ b/src/components/organisms/OverviewArticle.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <nuxt-link v-bind:to="linkToArticle">
+      <div class="flex">
+        <span class="graphic rounded-full flex items-center justify-center">
+          <span class="material-icons text-4xl">article</span>
+        </span>
+        <span class="description text-left ml-4">
+          <div class="text-xl">{{ content.title }}</div>
+          <div class="text-black text-opacity-54">{{ createdAt }}</div>
+        </span>
+      </div>
+    </nuxt-link>
+    <span class="tags flex mt-2 relative z-10">
+      <TagColumn v-bind:tags="propTags(content)" />
+    </span>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import TagColumn from '../molecules/TagColumn.vue'
+import { ArticleTag, PostFile, TopPageProps } from '@/models'
+import { encodePathURI } from '@/helpers/functions'
+
+@Component({
+  components: {
+    TagColumn,
+  },
+})
+export default class OverviewArticle extends Vue {
+  /**
+   * 表示する概要としてMarkdownファイルの情報を用いる。
+   */
+  @Prop({ required: true }) content!: PostFile
+
+  /**
+   * 作成日を yyyy/mm/dd フォーマットにして返す。
+   */
+  get createdAt() {
+    return this.content.created_at.replace(/-/g, '/')
+  }
+
+  /**
+   * タグからTagColumnsのプロパティを生成する。
+   */
+  get propTags() {
+    return (post: PostFile): ArticleTag[] => {
+      return post.tags.map((x) => {
+        return { name: x, value: x }
+      })
+    }
+  }
+
+  /**
+   * 記事ページへのリンク先を返す。
+   */
+  get linkToArticle() {
+    const pageRoute: string = '/posts/'
+    // URLエンコード処理を行っておく
+    return `${pageRoute}${encodePathURI(this.content.filename_noext)}`
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@use '@material/list';
+
+@include list.core-styles;
+
+.graphic {
+  background-color: rgba(0, 0, 0, 0.07);
+  width: 56px;
+  height: 56px;
+}
+</style>

--- a/src/components/organisms/Pagination.spec.ts
+++ b/src/components/organisms/Pagination.spec.ts
@@ -1,0 +1,33 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import Pagination from './Pagination.vue'
+import { Paging } from '@/models'
+
+describe('Pagination', () => {
+  test('is Vue', () => {
+    const pages = [1, 2, 3, 4, 5, 6, 7, 8]
+    const wrapper = shallowMount(Pagination, {
+      propsData: {
+        paging: {
+          current: 3,
+          pages: pages,
+        },
+        route: '/sample/hoge',
+      },
+      stubs: {
+        NuxtLink: true,
+      },
+    })
+
+    pages.forEach((x) =>
+      expect(wrapper.find(`[data-action=move-${x}]`).exists()).toBeTruthy()
+    )
+
+    expect(
+      wrapper.find('[data-action=prev] nuxtlink-stub').attributes().to
+    ).toBe('/sample/hoge?page=2')
+
+    expect(
+      wrapper.find('[data-action=next] nuxtlink-stub').attributes().to
+    ).toBe('/sample/hoge?page=4')
+  })
+})

--- a/src/components/organisms/Pagination.vue
+++ b/src/components/organisms/Pagination.vue
@@ -1,0 +1,86 @@
+<template functional>
+  <ul class="flex items-center">
+    <li class="flex" data-action="first">
+      <component
+        v-bind:is="injections.components.LinkButtonPagination"
+        v-bind:disabled="props.paging.current == 1"
+        v-bind:href="$options.methods.pager(props.route, 1)"
+        mode="first"
+      />
+    </li>
+    <li class="flex" data-action="prev">
+      <component
+        v-bind:is="injections.components.LinkButtonPagination"
+        v-bind:disabled="props.paging.current == 1"
+        v-bind:href="$options.methods.pager(props.route, props.paging.current - 1)"
+        mode="prev"
+      />
+    </li>
+    <li
+      v-for="(item, index) in (props.paging.pages)"
+      v-bind:key="index"
+      class="ml-2"
+      v-bind:data-action="`move-${item}`"
+    >
+      <component
+        v-bind:is="injections.components.LinkButtonPagination"
+        v-bind:disabled="props.paging.current == item"
+        v-bind:href="$options.methods.pager(props.route, item)"
+        v-bind:mode="{page: item}"
+      />
+    </li>
+    <li class="flex ml-2" data-action="next">
+      <component
+        v-bind:is="injections.components.LinkButtonPagination"
+        v-bind:disabled="props.paging.current == props.paging.pages.length"
+        v-bind:href="$options.methods.pager(props.route, props.paging.current + 1)"
+        mode="next"
+      />
+    </li>
+    <li class="flex" data-action="last">
+      <component
+        v-bind:is="injections.components.LinkButtonPagination"
+        v-bind:disabled="props.paging.current == props.paging.pages.length"
+        v-bind:href="$options.methods.pager(props.route, props.paging.pages.length)"
+        mode="last"
+      />
+    </li>
+  </ul>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Paging } from '@/models'
+import LinkButtonPagination from '../molecules/LinkButtonPagination.vue'
+
+@Component({
+  inject: {
+    components: {
+      default: {
+        LinkButtonPagination,
+      },
+    },
+  },
+})
+export default class Pagination extends Vue {
+  /**
+   * 現在ページおよびすべてのページ番号を格納。
+   */
+  @Prop({ required: true }) paging!: Paging
+
+  /**
+   * 表示ページのルートパス。
+   */
+  @Prop({ required: true }) route!: string
+
+  /**
+   * ページ移動先URLを返す。
+   */
+  pager(route: string, page: number): string {
+    return `${route}?page=${page}`
+  }
+}
+</script lang="ts">
+
+<style>
+</style>

--- a/src/components/templates/TopPage.spec.ts
+++ b/src/components/templates/TopPage.spec.ts
@@ -1,0 +1,32 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import TopPage from './TopPage.vue'
+
+describe('TopPage', () => {
+  test('is vue', () => {
+    const wrapper = shallowMount(TopPage, {
+      propsData: {
+        contents: {
+          path: 'hoge/foo/bar.md',
+          filename: 'bar.md',
+          filename_noext: 'bar',
+          title: 'Example',
+          created_at: '2020-06-22',
+          tags: ['hoge', 'foo'],
+        },
+        paging: {
+          current: 2,
+          pages: [1, 2, 3, 4, 5, 6],
+        },
+        route: '/posts',
+      },
+      stubs: {
+        HeadingLevel: true,
+        Pagination: true,
+      },
+    })
+
+    //console.log(wrapper.html())
+
+    expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+})

--- a/src/components/templates/TopPage.vue
+++ b/src/components/templates/TopPage.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="flex flex-col justify-center items-center text-center mx-auto">
+    <HeadingLevel v-bind:value="{ level: 1, text: 'Top' }" />
+    <ul class="overview w-3/4">
+      <li
+        class="flex-row justify-start hover:bg-lime hover:bg-opacity-25 p-2 mt-6"
+        v-for="(item, index) in contents"
+        v-bind:key="index"
+      >
+        <OverviewArticle v-bind:content="item" />
+      </li>
+    </ul>
+    <div class="opacity-75 hover:opacity-100 sticky bottom-0 py-4 mt-6">
+      <Pagination v-bind:paging="paging" v-bind:route="route" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import HeadingLevel from '../atoms/HeadingLevel.vue'
+import OverviewArticle from '../organisms/OverviewArticle.vue'
+import Pagination from '../organisms/Pagination.vue'
+import { Paging, PostFile, TopPageProps } from '@/models'
+
+@Component({
+  components: {
+    HeadingLevel,
+    OverviewArticle,
+    Pagination,
+  },
+})
+export default class TopPage extends Vue
+  implements TopPageProps.ContentsProp, TopPageProps.PaginationProp {
+  @Prop({ required: true }) contents!: PostFile[]
+
+  @Prop({ required: true }) paging!: Paging
+
+  @Prop({ required: true }) route!: string
+}
+</script>
+
+<style lang="scss" scoped>
+.pagination {
+  @apply fixed bottom-0;
+  @apply py-6;
+}
+</style>

--- a/src/helpers/functions.spec.ts
+++ b/src/helpers/functions.spec.ts
@@ -1,4 +1,4 @@
-import { maybeDo, splitLicense } from './functions'
+import { maybeDo, splitLicense, isObject, encodePathURI } from './functions'
 
 describe('Functions', () => {
   test('of maybeDo', () => {
@@ -97,5 +97,24 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`)
+  })
+
+  test('of isObject', () => {
+    expect(isObject('not object')).toBeFalsy()
+    expect(isObject(12345)).toBeFalsy()
+    expect(isObject(null)).toBeFalsy()
+    expect(isObject({})).toBeTruthy()
+    expect(isObject({ hoge: 123 })).toBeTruthy()
+    expect(isObject(() => 'function')).toBeTruthy()
+  })
+
+  test.each([
+    ['hoge', 'hoge'],
+    ['f o o', 'f+o+o'],
+    ['にほんご', '%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94'],
+    ['query=anything', 'query=anything'],
+    ['q=', 'q='],
+  ])('does encodePathURI(%s)', (x, expected) => {
+    expect(encodePathURI(x)).toEqual(expected)
   })
 })

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -36,3 +36,29 @@ export function splitLicense(generated: string) {
     }
   })
 }
+
+/**
+ * 引数がオブジェクトか否かを判定する。
+ *
+ * @param x オブジェクト判定対象
+ */
+export function isObject(x: unknown): x is object {
+  return x != null && (typeof x === 'object' || typeof x === 'function')
+}
+
+/**
+ * パスに対してURIエンコード処理を行った結果を返す。
+ * 完全なURIに対してのエンコード処理は未対応。
+ *
+ * @param path URIエンコード処理を行う対象文字列。完全なURIには未対応。
+ */
+export function encodePathURI(path: string): string {
+  let uri = new URLSearchParams(path).toString()
+
+  // クエリパラメータとしてエンコードするので末尾についた `=` は取り除く
+  if (uri.slice(-1, uri.length) === '=' && path.slice(-1, uri.length) !== '=') {
+    uri = uri.slice(0, -1)
+  }
+
+  return uri
+}

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="px-4 bg-background">
-    <main class="pt-6 text-black text-opacity-87">
-      <nuxt />
+  <div class="min-h-screen flex flex-col items-center mx-auto bg-background">
+    <main class="container flex-grow text-black text-opacity-87 px-4">
+      <nuxt class="mt-6" />
     </main>
   </div>
 </template>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,7 @@
 export * from './article'
 export * from './buttonAttribute'
 export * from './headingLevelType'
+export * from './paging'
+export * from './postFile'
 export * from './tag'
+export * from './vueProperties'

--- a/src/models/paging.ts
+++ b/src/models/paging.ts
@@ -1,0 +1,28 @@
+/**
+ * ページで表示するコンテンツとページングの状態を格納する。
+ */
+export interface PagingContent<T> {
+  contents: T[]
+  paging: Paging
+  route: string
+}
+
+/**
+ * ページング用の型。
+ *
+ * 現在ページと総ページ数を格納する。
+ */
+export interface Paging {
+  current: number
+  pages: number[]
+}
+
+/**
+ * ページング操作の種類。
+ *
+ * - `first` : 最初に戻る
+ * - `prev` : 1つ前に戻る
+ * - `next` : 1つ先に進む
+ * - `last` : 最後に進む
+ */
+export type PagingMode = 'first' | 'prev' | 'next' | 'last' | { page: string }

--- a/src/models/postFile.ts
+++ b/src/models/postFile.ts
@@ -1,0 +1,11 @@
+/**
+ * Markdownファイルについての情報を表す。
+ */
+export interface PostFile {
+  path: string
+  filename: string
+  filename_noext: string
+  title: string
+  created_at: string
+  tags: string[]
+}

--- a/src/models/vueProperties.ts
+++ b/src/models/vueProperties.ts
@@ -1,0 +1,32 @@
+import { Paging } from './paging'
+import { PostFile } from './postFile'
+
+/**
+ * トップページに関わるプロパティをもつインタフェースを定義。
+ */
+export namespace TopPageProps {
+  /**
+   * ページに表示するコンテンツのプロパティをもつインタフェース。
+   */
+  export interface ContentsProp {
+    /**
+     * ページに表示する _Markdown_ 記事の情報。
+     */
+    contents: PostFile[]
+  }
+
+  /**
+   * ページネーションに利用するプロパティをもつインタフェース。
+   */
+  export interface PaginationProp {
+    /**
+     * 現在ページとすべてのページ番号を格納。
+     */
+    paging: Paging
+
+    /**
+     * ページのルートパス。
+     */
+    route: string
+  }
+}

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,62 +1,54 @@
 <template>
-  <div class="container">
-    <div>
-      <logo />
-      <h1 class="title">vlife-blog</h1>
-      <h2 class="subtitle">Generate a static site with Nuxt.js</h2>
-      <div class="links">
-        <a href="https://nuxtjs.org/" target="_blank" class="button--green">Documentation</a>
-        <a href="https://github.com/nuxt/nuxt.js" target="_blank" class="button--grey">GitHub</a>
-      </div>
-    </div>
-  </div>
+  <TopPage v-bind:contents="contents" v-bind:paging="paging" v-bind:route="route" />
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-import Logo from '~/components/atoms/LogoNuxt.vue'
+import { Component, Vue } from 'nuxt-property-decorator'
+import TopPage from '../components/templates/TopPage.vue'
+import { posts } from '@/assets/markdowns/posts/postlist.json'
+import { PagingContent, PostFile } from '@/models'
 
-export default Vue.extend({
+@Component({
+  watchQuery: ['page'],
+  // クエリパラメータでページネーション
+  asyncData(ctx): PagingContent<PostFile> {
+    // ページ番号をクエリパラメータ `page` から取得。
+    const page = Number.parseInt(ctx.query.page?.toString() ?? 1)
+    //console.log(`page query: ${page}`)
+
+    // 1ページあたりの表示件数
+    const count = 20
+    // 総ページ数
+    const size = Math.ceil(posts.length / count)
+    // ページに表示するコンテンツの配列の開始番号
+    const start = (page - 1) * count
+
+    return {
+      contents: posts.slice(start, start + count),
+      paging: {
+        current: page,
+        pages: [...new Array(size)].map((_, i) => i + 1),
+      },
+      route: ctx.route.path,
+    }
+  },
   components: {
-    Logo,
+    TopPage,
+  },
+  head: () => {
+    return {
+      title: 'Home',
+    }
   },
 })
+export default class Home extends Vue {}
 </script>
 
 <style lang="scss">
-/* Sample `apply` at-rules with Tailwind CSS
+/* Sample `apply` at-rules with Tailwind CSS */
+/*
 .container {
   @apply min-h-screen flex justify-center items-center text-center mx-auto;
 }
 */
-.container {
-  margin: 0 auto;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
-
-.title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  display: block;
-  font-weight: 300;
-  font-size: 100px;
-  color: #35495e;
-  letter-spacing: 1px;
-}
-
-.subtitle {
-  font-weight: 300;
-  font-size: 42px;
-  color: #526488;
-  word-spacing: 5px;
-  padding-bottom: 15px;
-}
-
-.links {
-  padding-top: 15px;
-}
 </style>


### PR DESCRIPTION
トップページを作成。
Markdownファイルごとに記事ページの概要一覧を表示。

- fix: fix yarn dev script
- fix: fix classes on disabled
- fix: fix layout css
- fix: change a top page
- feat: create pagination types
- feat: create atom of pagination button
- feat: create a molecule of pagination
- feat: create a organisms of pagination
- feat: add organisms of orverview article
- feat: create a top page template

close #52 