### PR TITLE
fix: デバッグ用の要素を非表示になるよう修正

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,5 +14,6 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/src/components/**/*.vue',
     //'<rootDir>/src/pages/**/*.vue',
+    '<rootDir>/src/mixins/**/*.ts',
   ],
 }

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -3,25 +3,32 @@
     <HeadingLevel v-bind:value="headingLevel" />
     <div class="mt-4">
       <TagColumn v-bind:tags="tags" v-on:click="onClickTag" />
-      <DatesDisplay class="flex justify-end" v-bind:item="article | dateFormats" />
+      <DatesDisplay
+        class="flex justify-end"
+        v-bind:item="article | dateFormats"
+      />
     </div>
     <hr class="mt-2 border-gray-600" />
-
-    <div class="flex mt-4">
+    <!-- 要素テスト用 -->
+    <div v-if="isDebug(article.tags)" class="flex mt-4">
       <ButtonMaterial />
-      <ButtonMaterial class="ml-4" v-bind:property="{label: 'hoge'}" />
-      <ButtonMaterial class="ml-4" v-bind:property="{type: 'outlined'}" />
-      <ButtonMaterial class="ml-4" v-bind:property="{type: 'raised', icon: 'bookmark'}" />
+      <ButtonMaterial class="ml-4" v-bind:property="{ label: 'hoge' }" />
+      <ButtonMaterial class="ml-4" v-bind:property="{ type: 'outlined' }" />
+      <ButtonMaterial
+        class="ml-4"
+        v-bind:property="{ type: 'raised', icon: 'bookmark' }"
+      />
     </div>
-
+    <!-- 要素テスト終了 -->
     <ArticleBody class="mt-6" v-bind:renderd="article.body" />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Component, mixins, Prop, Vue } from 'nuxt-property-decorator'
 import moment from 'moment'
 import { Article, ArticleTag, HeadingLevelType } from '@/models'
+import { DebugMixin } from '@/mixins/debugMixin'
 import { Content } from '*.md'
 
 import ArticleBody from '../organisms/ArticleBody.vue'
@@ -57,7 +64,7 @@ import ButtonMaterial from '../atoms/ButtonMaterial.vue'
     },
   },
 })
-export default class ArticlePosted extends Vue {
+export default class ArticlePosted extends mixins(DebugMixin) {
   /**
    * _Front Matter_ つきの _Markdown_ ファイルの内容。
    */

--- a/src/components/templates/TopPage.spec.ts
+++ b/src/components/templates/TopPage.spec.ts
@@ -2,23 +2,30 @@ import { shallowMount, Wrapper } from '@vue/test-utils'
 import TopPage from './TopPage.vue'
 
 describe('TopPage', () => {
-  test('is vue', () => {
-    const wrapper = shallowMount(TopPage, {
-      propsData: {
-        contents: {
+  const createProps = (content?: object) => {
+    return {
+      contents: [
+        {
           path: 'hoge/foo/bar.md',
           filename: 'bar.md',
           filename_noext: 'bar',
           title: 'Example',
           created_at: '2020-06-22',
           tags: ['hoge', 'foo'],
+          ...content,
         },
-        paging: {
-          current: 2,
-          pages: [1, 2, 3, 4, 5, 6],
-        },
-        route: '/posts',
+      ],
+      paging: {
+        current: 2,
+        pages: [1, 2, 3, 4, 5, 6],
       },
+      route: '/posts',
+    }
+  }
+
+  test('is vue', () => {
+    const wrapper = shallowMount(TopPage, {
+      propsData: createProps(),
       stubs: {
         HeadingLevel: true,
         Pagination: true,
@@ -28,5 +35,15 @@ describe('TopPage', () => {
     //console.log(wrapper.html())
 
     expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+
+  test('does notDebugContents', () => {
+    let instance = new TopPage({ propsData: createProps() }) as any
+    expect(instance.notDebugContents.length).toBe(1)
+
+    instance = new TopPage({
+      propsData: createProps({ tags: ['draft', 'hoge', 'foo'] }),
+    }) as any
+    expect(instance.notDebugContents.length).toBe(0)
   })
 })

--- a/src/components/templates/TopPage.vue
+++ b/src/components/templates/TopPage.vue
@@ -4,7 +4,7 @@
     <ul class="overview w-3/4">
       <li
         class="flex-row justify-start hover:bg-lime hover:bg-opacity-25 p-2 mt-6"
-        v-for="(item, index) in contents"
+        v-for="(item, index) in notDebugContents"
         v-bind:key="index"
       >
         <OverviewArticle v-bind:content="item" />
@@ -17,11 +17,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Component, mixins, Prop, Vue } from 'nuxt-property-decorator'
 import HeadingLevel from '../atoms/HeadingLevel.vue'
 import OverviewArticle from '../organisms/OverviewArticle.vue'
 import Pagination from '../organisms/Pagination.vue'
 import { Paging, PostFile, TopPageProps } from '@/models'
+import { DebugMixin } from '@/mixins/debugMixin'
 
 @Component({
   components: {
@@ -30,13 +31,20 @@ import { Paging, PostFile, TopPageProps } from '@/models'
     Pagination,
   },
 })
-export default class TopPage extends Vue
+export default class TopPage extends mixins(DebugMixin)
   implements TopPageProps.ContentsProp, TopPageProps.PaginationProp {
   @Prop({ required: true }) contents!: PostFile[]
 
   @Prop({ required: true }) paging!: Paging
 
   @Prop({ required: true }) route!: string
+
+  /**
+   * デバッグ用以外の `contents` を返す。
+   */
+  get notDebugContents(): PostFile[] {
+    return this.contents.filter((x) => !this.isDebug(x.tags))
+  }
 }
 </script>
 

--- a/src/mixins/debugMixin.spec.ts
+++ b/src/mixins/debugMixin.spec.ts
@@ -1,0 +1,17 @@
+import { DebugMixin } from './debugMixin'
+
+describe('DebugMixin', () => {
+  const debug = new DebugMixin()
+
+  test.each([
+    [['hoge', 'foo'], false],
+    [[], false],
+    [['hoge', 'WIP'], true],
+    [['draft', 'foo'], true],
+    [['WIP', 'draft'], true],
+    [['wip'], false],
+    [['DRAFT'], false],
+  ])('does isDebug(%o)', (tags, expected) => {
+    expect(debug.isDebug(tags)).toBe(expected)
+  })
+})

--- a/src/mixins/debugMixin.ts
+++ b/src/mixins/debugMixin.ts
@@ -1,0 +1,23 @@
+import Vue from 'vue'
+
+/**
+ * デバッグ用関数を提供する _Vue mixin_
+ *
+ * ## Methods
+ *
+ * - `isDebug` : 記事ページにおけるデバッグ判定
+ */
+export const DebugMixin = Vue.extend({
+  methods: {
+    /**
+     * 記事に付与されているタグ情報からデバッグ状態を判定する。
+     *
+     * `WIP` または `draft` タグが含まれていればデバックであると判断する。
+     *
+     * @param tags 記事のタグ
+     */
+    isDebug(tags: string[]) {
+      return ['WIP', 'draft'].some((x) => tags.includes(x))
+    },
+  },
+})


### PR DESCRIPTION
トップページにおけるデモ記事および記事ページにおけるボタン要素をそれぞれ非表示にするよう修正。

- feat: create mixin for checking debug on article
- fix: fix to check debug

close #65, close #66