### PR TITLE
feat: ヘッダーを作成および適用

### DIFF
--- a/src/components/atoms/LinkItemOnAppBar.spec.ts
+++ b/src/components/atoms/LinkItemOnAppBar.spec.ts
@@ -1,0 +1,19 @@
+import { shallowMount } from '@vue/test-utils'
+import LinkItemOnAppBar from './LinkItemOnAppBar.vue'
+
+describe('LinkItemOnAppBar', () => {
+  test.each([
+    ['/', '/sample', true],
+    ['/', '/?page=9', true], // must exclude parametor
+    ['/hoge', '/hoge/foo', false],
+    ['/hoge', '/foo/bar', false],
+  ])('is to link %s, on path %s', (x, y, isExact) => {
+    const wrapper = shallowMount(LinkItemOnAppBar, {
+      propsData: { href: x, route: y },
+      stubs: { NuxtLink: true },
+    })
+
+    expect(wrapper.find('nuxtlink-stub').attributes().to).toBe(x)
+    expect(wrapper.find('nuxtlink-stub[exact]').exists()).toBe(isExact)
+  })
+})

--- a/src/components/atoms/LinkItemOnAppBar.vue
+++ b/src/components/atoms/LinkItemOnAppBar.vue
@@ -1,0 +1,39 @@
+<template functional>
+  <nuxt-link
+    v-bind:class="[data.class, data.staticClass]"
+    v-bind:to="props.href"
+    v-bind:exact="$options.methods.isRootExact(props.href, props.route)"
+  >
+    <slot></slot>
+  </nuxt-link>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { LinkProps } from '@/models'
+
+@Component
+export default class LinkItemOnAppBar extends Vue
+  implements LinkProps.ToLinkProp, LinkProps.RouteProp {
+  @Prop({ required: true }) href!: string
+
+  @Prop({ required: true }) route!: string
+
+  /**
+   * アクティブリンクの `exact` 属性の付与判定に用いる。
+   *
+   * リンク先が `/` かつ現在のルートパスが '/' でない場合に 'true' を返す。
+   * これにより、パラメータがついている場合も許容する。
+   */
+  isRootExact(href: string, route: string): boolean {
+    return href === '/' && route !== '/'
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// アクティブリンク
+.nuxt-link-active {
+  @apply border-b-2 border-white border-opacity-54;
+}
+</style>

--- a/src/components/atoms/SimpleIconsImage.spec.ts
+++ b/src/components/atoms/SimpleIconsImage.spec.ts
@@ -1,0 +1,27 @@
+import { shallowMount } from '@vue/test-utils'
+import SimpleIconsImage from './SimpleIconsImage.vue'
+
+describe('SimpleIconsImage', () => {
+  test.each([
+    [
+      'github',
+      'alt',
+      'github icon',
+      'https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/github.svg',
+    ],
+    [
+      'twitter',
+      'this is my account',
+      undefined,
+      'https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/twitter.svg',
+    ],
+  ])('show "%s" image from CDN', (name, alt, title, url) => {
+    const wrapper = shallowMount(SimpleIconsImage, {
+      propsData: { name: name, alt: alt, title: title },
+    }).find('.simpleicons')
+
+    expect(wrapper.attributes().src).toBe(url)
+    expect(wrapper.attributes().alt).toBe(alt)
+    expect(wrapper.attributes().title).toBe(title)
+  })
+})

--- a/src/components/atoms/SimpleIconsImage.vue
+++ b/src/components/atoms/SimpleIconsImage.vue
@@ -1,0 +1,44 @@
+<template functional>
+  <img
+    class="simpleicons"
+    v-bind:class="[data.class, data.staticClass]"
+    v-bind:src="$options.methods.link(props.name)"
+    v-bind:alt="props.alt"
+    v-bind:title="props.title"
+  />
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+/**
+ * Simple Icons をCDNから利用するコンポーネント。
+ */
+@Component
+export default class SimpleIconsImage extends Vue {
+  /**
+   * アイコン名。
+   */
+  @Prop({ required: true }) name!: string
+
+  /**
+   * 代替テキスト。
+   */
+  @Prop({ required: true }) alt!: string
+
+  /**
+   * 画像タイトル。
+   */
+  @Prop({ required: false }) title?: string
+
+  /**
+   * アイコン名からCDNへのURLを生成して返す。
+   */
+  link(name: string): string {
+    return `https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/${name}.svg`
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/organisms/TopAppBar.spec.ts
+++ b/src/components/organisms/TopAppBar.spec.ts
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils'
+import TopAppBar from './TopAppBar.vue'
+
+describe('TopAppBar', () => {
+  test('is Vue', () => {
+    const wrapper = shallowMount(TopAppBar, {
+      mocks: { $route: { path: '/' } },
+      stubs: { NuxtLink: true },
+    })
+
+    expect(wrapper.isVueInstance()).toBeTruthy()
+    expect((wrapper.vm as any).routePath).toBe('/')
+  })
+})

--- a/src/components/organisms/TopAppBar.vue
+++ b/src/components/organisms/TopAppBar.vue
@@ -1,0 +1,82 @@
+<template>
+  <header class="mdc-top-app-bar relative">
+    <div class="mdc-top-app-bar__row">
+      <div class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+        <nuxt-link class="mdc-top-app-bar__title" to="/">Vがある生活</nuxt-link>
+      </div>
+      <nav class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+        <ul class="flex">
+          <li>
+            <LinkItemOnAppBar
+              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-gray-600 hover:bg-opacity-15"
+              href="/"
+              v-bind:route="routePath"
+            >Home</LinkItemOnAppBar>
+          </li>
+          <li class="ml-2">
+            <LinkItemOnAppBar
+              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-gray-600 hover:bg-opacity-15"
+              href="/license"
+              v-bind:route="routePath"
+            >License</LinkItemOnAppBar>
+          </li>
+        </ul>
+        <ul class="flex ml-4">
+          <li class="flex items-center">
+            <a
+              class="material-icons mdc-top-app-bar__action-item mdc-icon-button"
+              href="https://twitter.com/akiakiS101"
+              target="_blank"
+            >
+              <SimpleIconsImage name="twitter" alt="To twitter account" />
+            </a>
+          </li>
+          <li class="flex items-center">
+            <a
+              class="material-icons mdc-top-app-bar__action-item mdc-icon-button"
+              href="https://github.com/akiakishitai/vlife-blog"
+              target="_blank"
+            >
+              <SimpleIconsImage name="github" alt="To github source" />
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import LinkItemOnAppBar from '../atoms/LinkItemOnAppBar.vue'
+import LinkWrapper from '../atoms/LinkWrapper.vue'
+import SimpleIconsImage from '../atoms/SimpleIconsImage.vue'
+
+@Component({
+  components: { LinkWrapper, LinkItemOnAppBar, SimpleIconsImage },
+})
+export default class TopAppBar extends Vue {
+  get routePath() {
+    //console.log(`route path: ${this.$nuxt.$route.path}`)
+
+    return this.$route.path
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+//@use 'material_theme.scss';
+@use '@material/theme' with ($primary: #2e2e2e);
+@use "@material/icon-button";
+@use "@material/top-app-bar/mdc-top-app-bar";
+
+@include icon-button.core-styles;
+
+.mdc-top-app-bar.relative {
+  position: relative;
+}
+
+.simpleicons {
+  filter: invert(1);
+}
+</style>

--- a/src/components/templates/LicensePage.vue
+++ b/src/components/templates/LicensePage.vue
@@ -6,6 +6,10 @@
       Using fonts:
       <slot name="font"></slot>
     </div>
+    <div class="mt-8">
+      Using icons:
+      <slot name="icon"></slot>
+    </div>
     <div class="js-library">
       <div class="mt-8">{{ description }}</div>
       <LicenseYarnGenerated v-bind:licenses="splitLicense" />

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,57 +1,27 @@
 <template>
   <div class="min-h-screen flex flex-col items-center mx-auto bg-background">
+    <TopAppBar />
     <main class="container flex-grow text-black text-opacity-87 px-4">
       <nuxt class="mt-6" />
     </main>
   </div>
 </template>
 
+<script lang="ts">
+import Vue from 'vue'
+import TopAppBar from '../components/organisms/TopAppBar.vue'
+
+export default Vue.extend({
+  components: {
+    TopAppBar,
+  },
+})
+</script>
+
 <style lang="scss">
 html {
-  font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+  font-family: 'Noto Sans CJK JP', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     Roboto, 'Helvetica Neue', Arial, sans-serif;
   font-size: 16px;
-  word-spacing: 1px;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  box-sizing: border-box;
-}
-
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-  margin: 0;
-}
-
-.button--green {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #3b8070;
-  color: #3b8070;
-  text-decoration: none;
-  padding: 10px 30px;
-}
-
-.button--green:hover {
-  color: #fff;
-  background-color: #3b8070;
-}
-
-.button--grey {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #35495e;
-  color: #35495e;
-  text-decoration: none;
-  padding: 10px 30px;
-  margin-left: 15px;
-}
-
-.button--grey:hover {
-  color: #fff;
-  background-color: #35495e;
 }
 </style>

--- a/src/models/vueProperties.ts
+++ b/src/models/vueProperties.ts
@@ -30,3 +30,22 @@ export namespace TopPageProps {
     route: string
   }
 }
+
+/**
+ * リンクに関わるプロパティを定義するインタフェース。
+ */
+export namespace LinkProps {
+  export interface ToLinkProp {
+    /**
+     * リンク先URL。
+     */
+    href: string
+  }
+
+  export interface RouteProp {
+    /**
+     * 表示ページのルートパス。
+     */
+    route: string
+  }
+}

--- a/src/pages/license/index.vue
+++ b/src/pages/license/index.vue
@@ -5,9 +5,17 @@
         <ul class="list-disc ml-6">
           <li class="mt-8">
             Material Design icons: Licensed under
-            <LinkWrapper href="https://www.apache.org/licenses/LICENSE-2.0"
-              >Apache license version 2.0</LinkWrapper
-            >.
+            <LinkWrapper
+              href="https://www.apache.org/licenses/LICENSE-2.0"
+            >Apache license version 2.0</LinkWrapper>.
+          </li>
+        </ul>
+      </template>
+      <template v-slot:icon>
+        <ul class="list-disc ml-6">
+          <li class="mt-8">
+            Simple Icons: Licensed under
+            <LinkWrapper href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal</LinkWrapper>.
           </li>
         </ul>
       </template>


### PR DESCRIPTION
各ページおよびSNSアカウントへのリンクを記載したヘッダーを作成。
デフォルトの `layout` へ適用。

- feat: add header navigation
- feat: add a license of simle icons

close #67