### PR TITLE
markup: use simple icons on markdown

### DIFF
--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -27,3 +27,14 @@
   content: attr(data-lang);
   display: block;
 }
+
+/* Simples Icons in markdown */
+.markdown-body img[src^="https://cdn.jsdelivr.net/npm/simple-icons"]
+{
+  @apply inline;
+  @apply w-5;
+  @apply align-baseline;
+  @apply opacity-87;
+
+  /* filter: invert(1); */
+}


### PR DESCRIPTION
_Markdown_ ファイルで _Simple Icons_ 使用する場合のCSS設定を記述。

close #73