### PR TITLE
fix: html validation checked

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,6 +11,9 @@ export default {
   head: {
     title: process.env.npm_package_name || '',
     titleTemplate: '%s - Vがある生活',
+    htmlAttrs: {
+      lang: 'ja',
+    },
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/src/components/atoms/ButtonPagination.spec.ts
+++ b/src/components/atoms/ButtonPagination.spec.ts
@@ -34,13 +34,13 @@ describe('ButtonPagination', () => {
   test('is disabled', () => {
     expect(
       createWrapper({ isDisabled: true, page: 1 }).contains(
-        '.pagination-btn[disabled]'
+        '.pagination-btn.disabled'
       )
     ).toBeTruthy()
 
     expect(
       createWrapper({ isDisabled: true, icon: 'done' }).contains(
-        '.pagination-icon[disabled]'
+        '.pagination-icon.disabled'
       )
     ).toBeTruthy()
   })

--- a/src/components/atoms/ButtonPagination.vue
+++ b/src/components/atoms/ButtonPagination.vue
@@ -1,18 +1,17 @@
 <template functional>
-  <button
+  <div
     v-if="props.property.icon == null"
     class="mdc-button pagination-btn"
-    v-bind:class="[data.class, data.staticClass]"
-    v-bind:disabled="props.property.isDisabled"
+    v-bind:class="[data.class, data.staticClass, { disabled: props.property.isDisabled }]"
   >
     <div class="mdc-button__ripple"></div>
     <span class="mdc-button__label">{{ props.property.page }}</span>
-  </button>
-  <button
+  </div>
+  <div
     v-else
     class="mdc-icon-button material-icons pagination-icon"
-    v-bind:disabled="props.property.isDisabled"
-  >{{ props.property.icon }}</button>
+    v-bind:class="{ disabled: props.property.isDisabled }"
+  >{{ props.property.icon }}</div>
 </template>
 
 <script lang="ts">
@@ -55,7 +54,7 @@ export default class ButtonPagination extends Vue {
   min-width: 40px;
   --mdc-typography-button-font-size: 1.25rem;
 
-  &[disabled] {
+  &.disabled {
     background: #bdbdbd;
   }
 }

--- a/src/components/atoms/LinkWrapper.spec.ts
+++ b/src/components/atoms/LinkWrapper.spec.ts
@@ -25,7 +25,7 @@ describe('LinkWrapper', () => {
 
   test('is disable', () => {
     const url = 'https://example.com'
-    expect(createWrapper(url).contains('.link[disabled]')).toBeFalsy()
-    expect(createWrapper(url, true).contains('.link[disabled]')).toBeTruthy()
+    expect(createWrapper(url).contains('.link.disabled')).toBeFalsy()
+    expect(createWrapper(url, true).contains('.link.disabled')).toBeTruthy()
   })
 })

--- a/src/components/atoms/LinkWrapper.vue
+++ b/src/components/atoms/LinkWrapper.vue
@@ -2,18 +2,13 @@
   <a
     v-if="props.href.match(/^https?:\/\//) != null"
     class="link"
+    v-bind:class="{ disabled: props.disabled }"
     v-bind:href="props.href"
     target="_blank"
-    v-bind:disabled="props.disabled"
   >
     <slot></slot>
   </a>
-  <nuxt-link
-    v-else
-    v-bind:to="props.href"
-    class="link"
-    v-bind:disabled="props.disabled"
-  >
+  <nuxt-link v-else v-bind:to="props.href" class="link" v-bind:class="{ disabled: props.disabled }">
     <slot></slot>
   </nuxt-link>
 </template>
@@ -31,12 +26,12 @@ export default class LinkWrapper extends Vue {
    */
   @Prop({ required: true }) href!: string
 
-  @Prop() disabled!: boolean
+  @Prop({ required: false }) disabled?: boolean
 }
 </script>
 
 <style lang="scss" scoped>
-.link:not([disabled]) {
+.link:not(.disabled) {
   @apply text-indigo-500;
 
   &:visited {
@@ -48,7 +43,7 @@ export default class LinkWrapper extends Vue {
   }
 }
 
-.link[disabled] {
+.link.disabled {
   /* リンクを無効化 */
   pointer-events: none;
 }

--- a/src/components/atoms/TagChip.vue
+++ b/src/components/atoms/TagChip.vue
@@ -6,8 +6,8 @@
     v-on:click="$options.methods.maybeDo(listeners.click, props.value)"
   >
     <div class="mdc-chip__ripple"></div>
-    <i class="material-icons mdc-chip__icon mdc-chip__icon--leading">local_offer</i>
-    <span role="gridcell">
+    <i class="material-icons mdc-chip__icon mdc-chip__icon--leading" role="cell">local_offer</i>
+    <span role="cell">
       <span role="button" tabindex="0" class="mdc-chip__primary-action">
         <span class="mdc-chip__text">{{ props.tag }}</span>
       </span>

--- a/src/components/molecules/LinkButtonPagination.spec.ts
+++ b/src/components/molecules/LinkButtonPagination.spec.ts
@@ -16,15 +16,15 @@ describe('LinkButtonPagination', () => {
     const example = 'https://example.com'
     let wrapper = createWrapper(example, 'first')
     expect(wrapper.find('[href]').attributes().href).toBe(example)
-    expect(wrapper.contains('[disabled]')).toBeFalsy()
+    expect(wrapper.contains('.disabled')).toBeFalsy()
 
     wrapper = createWrapper(example, { page: '7' })
     expect(wrapper.find('[href]').attributes().href).toBe(example)
-    expect(wrapper.contains('[disabled]')).toBeFalsy()
+    expect(wrapper.contains('.disabled')).toBeFalsy()
 
     wrapper = createWrapper(example, { page: '7' }, true)
     expect(wrapper.find('[href]').attributes().href).toBe(example)
-    expect(wrapper.contains('[disabled]')).toBeTruthy()
+    expect(wrapper.contains('.disabled')).toBeTruthy()
   })
 
   test('of propByPaging', () => {

--- a/src/components/molecules/TagColumn.vue
+++ b/src/components/molecules/TagColumn.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <div class="mdc-chip-set">
+  <div class="mdc-chip-set" role="table">
     <component
       v-bind:is="injections.components.TagChip"
       v-for="(item, index) in $options.methods.skipEmpty(props.tags)"

--- a/src/components/organisms/OverviewArticle.vue
+++ b/src/components/organisms/OverviewArticle.vue
@@ -5,15 +5,15 @@
         <span class="graphic rounded-full flex items-center justify-center">
           <span class="material-icons text-4xl">article</span>
         </span>
-        <span class="description text-left ml-4">
+        <div class="description text-left ml-4">
           <div class="text-xl">{{ content.title }}</div>
           <div class="text-black text-opacity-54">{{ createdAt }}</div>
-        </span>
+        </div>
       </div>
     </nuxt-link>
-    <span class="tags flex mt-2 relative z-10">
+    <div class="tags flex mt-2 relative z-10">
       <TagColumn v-bind:tags="propTags(content)" />
-    </span>
+    </div>
   </div>
 </template>
 

--- a/src/components/organisms/Pagination.vue
+++ b/src/components/organisms/Pagination.vue
@@ -80,7 +80,7 @@ export default class Pagination extends Vue {
     return `${route}?page=${page}`
   }
 }
-</script lang="ts">
+</script>
 
 <style>
 </style>

--- a/src/components/organisms/TopAppBar.vue
+++ b/src/components/organisms/TopAppBar.vue
@@ -4,7 +4,7 @@
       <div class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
         <nuxt-link class="mdc-top-app-bar__title" to="/">Vがある生活</nuxt-link>
       </div>
-      <nav class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+      <nav class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
         <ul class="flex">
           <li>
             <LinkItemOnAppBar


### PR DESCRIPTION
_W3C Markup Validation Service_ を利用してHTMLを修正。

CSSの `too few valued for the property transform` エラーはフレームワーク側の問題のようなので今回は無視する。

- fix: fix value for role attribute
- fix: fix attribute disable not allowed on a
- fix: div not allowed as child of span
- fix: button must not to be a descendant of the a
- fix: remove an unnecessary code
- fix: add a lang ja attribute

close #72