### PR TITLE
fix: 色指定でmaterial-colorsを使うように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "front-matter": "^3.1.0",
     "markdown-it": "^10.0.0",
     "markdown-it-attrs": "^3.0.3",
+    "material-colors": "^1.2.6",
     "material-components-web": "^6.0.0",
     "moment": "^2.24.0",
     "nuxt": "^2.0.0",

--- a/src/assets/css/material_theme.scss
+++ b/src/assets/css/material_theme.scss
@@ -1,6 +1,10 @@
-$primary-color: #ffc107;
-$secondary-color: #26c6da;
-$background-color: #efebe9;
+// Material Colors
+@use 'material-colors/dist/colors.scss';
+@forward 'material-colors/dist/colors.scss';
+
+$primary-color: colors.$md-amber-500;
+$secondary-color: colors.$md-cyan-400;
+$background-color: colors.$md-grey-200;
 
 // マテリアルデザインのカラーテーマ
 @forward '@material/theme' with (

--- a/src/components/atoms/ButtonPagination.vue
+++ b/src/components/atoms/ButtonPagination.vue
@@ -49,19 +49,23 @@ export default class ButtonPagination extends Vue {
 @use "@material/icon-button" as icon;
 
 .pagination-btn {
-  @include button.ink-color(rgba(0, 0, 0, 0.87));
-  @include button.disabled-ink-color(rgba(0, 0, 0, 0.54));
+  @include button.ink-color(rgba(black, 0.87));
+  @include button.disabled-ink-color(rgba(black, 0.54));
   min-width: 40px;
   --mdc-typography-button-font-size: 1.25rem;
 
   &.disabled {
-    background: #bdbdbd;
+    @apply bg-grey-400 bg-opacity-54;
   }
 }
 
 .pagination-icon {
   @include icon.icon-size(32px, 32px, 4px);
-  @include icon.ink-color(rgba(0, 0, 0, 0.87));
-  @include icon.disabled-ink-color(rgba(0, 0, 0, 0.38));
+  @include icon.ink-color(rgba(black, 0.87));
+  @include icon.disabled-ink-color(rgba(black, 0.38));
+
+  &.disabled {
+    @include icon.ink-color(rgba(theme.$md-grey-600, 0.87));
+  }
 }
 </style>

--- a/src/components/atoms/LicenseYarnGenerated.vue
+++ b/src/components/atoms/LicenseYarnGenerated.vue
@@ -2,7 +2,9 @@
   <ul class="list-disc ml-6" v-if="props.licenses.length > 0">
     <li class="mt-8" v-for="(item, index) in props.licenses" v-bind:key="index">
       <div v-for="(elem, idx) in item.desc" v-bind:key="idx">{{ elem }}</div>
-      <pre class="whitespace-pre-wrap bg-gray-300 bg-opacity-75 p-4 mt-4">{{ item.body }}</pre>
+      <pre class="whitespace-pre-wrap bg-grey-300 p-4 mt-4">{{
+        item.body
+      }}</pre>
     </li>
   </ul>
 </template>
@@ -20,5 +22,4 @@ export default class LicenseYarnGenerated extends Vue {
 }
 </script>
 
-<style>
-</style>
+<style></style>

--- a/src/components/atoms/TagChip.vue
+++ b/src/components/atoms/TagChip.vue
@@ -56,5 +56,13 @@ export default class TagChip extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@use "material_theme" as theme;
 @use "@material/chips/mdc-chips";
+@use "@material/chips";
+
+.mdc-chip {
+  @include chips.fill-color(transparent);
+  @include chips.outline(2px, solid, theme.$primary-color);
+  @include chips.leading-icon-color(theme.$md-grey-700, 0.87);
+}
 </style>

--- a/src/components/organisms/OverviewArticle.vue
+++ b/src/components/organisms/OverviewArticle.vue
@@ -1,17 +1,24 @@
 <template>
-  <div>
-    <nuxt-link v-bind:to="linkToArticle">
+  <div class="relative text-left">
+    <nuxt-link class="link-article" v-bind:to="linkToArticle">
       <div class="flex">
-        <span class="graphic rounded-full flex items-center justify-center">
+        <!-- 画像 -->
+        <span
+          class="graphic rounded-full flex items-center justify-center bg-grey-400 bg-opacity-38"
+        >
           <span class="material-icons text-4xl">article</span>
         </span>
+
+        <!-- テキスト情報 -->
         <div class="description text-left ml-4">
           <div class="text-xl">{{ content.title }}</div>
           <div class="text-black text-opacity-54">{{ createdAt }}</div>
         </div>
       </div>
     </nuxt-link>
-    <div class="tags flex mt-2 relative z-10">
+
+    <!-- タグ一覧 -->
+    <div class="inline-flex relative z-10 mt-4">
       <TagColumn v-bind:tags="propTags(content)" />
     </div>
   </div>
@@ -69,8 +76,18 @@ export default class OverviewArticle extends Vue {
 @include list.core-styles;
 
 .graphic {
-  background-color: rgba(0, 0, 0, 0.07);
   width: 56px;
   height: 56px;
+}
+
+// クリック反応範囲の拡大
+.link-article::before {
+  @apply block;
+  @apply absolute left-0 top-0;
+  @apply pointer-events-auto;
+  @apply bg-transparent;
+  @apply w-full h-full;
+
+  content: '';
 }
 </style>

--- a/src/components/organisms/TopAppBar.vue
+++ b/src/components/organisms/TopAppBar.vue
@@ -1,24 +1,28 @@
 <template>
   <header class="mdc-top-app-bar relative">
     <div class="mdc-top-app-bar__row">
-      <div class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+      <div
+        class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start"
+      >
         <nuxt-link class="mdc-top-app-bar__title" to="/">Vがある生活</nuxt-link>
       </div>
       <nav class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
         <ul class="flex">
           <li>
             <LinkItemOnAppBar
-              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-gray-600 hover:bg-opacity-15"
+              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-grey-500 hover:bg-opacity-15"
               href="/"
               v-bind:route="routePath"
-            >Home</LinkItemOnAppBar>
+              >Home</LinkItemOnAppBar
+            >
           </li>
           <li class="ml-2">
             <LinkItemOnAppBar
-              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-gray-600 hover:bg-opacity-15"
+              class="mdc-top-app-bar__action-item p-2 rounded-t hover:bg-grey-500 hover:bg-opacity-15"
               href="/license"
               v-bind:route="routePath"
-            >License</LinkItemOnAppBar>
+              >License</LinkItemOnAppBar
+            >
           </li>
         </ul>
         <ul class="flex ml-4">

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -8,7 +8,7 @@
         v-bind:item="article | dateFormats"
       />
     </div>
-    <hr class="mt-2 border-gray-600" />
+    <hr class="mt-2 border-grey-500" />
     <!-- 要素テスト用 -->
     <div v-if="isDebug(article.tags)" class="flex mt-4">
       <ButtonMaterial />

--- a/src/components/templates/TopPage.vue
+++ b/src/components/templates/TopPage.vue
@@ -5,7 +5,7 @@
     <!-- slot end. -->
     <ul class="overview w-3/4">
       <li
-        class="flex-row justify-start hover:bg-lime hover:bg-opacity-25 p-2 mt-6"
+        class="flex-row justify-start hover:bg-primary hover:bg-opacity-15 p-2 mt-6"
         v-for="(item, index) in notDebugContents"
         v-bind:key="index"
       >

--- a/src/plugins/markdown-it/customRules.ts
+++ b/src/plugins/markdown-it/customRules.ts
@@ -136,7 +136,7 @@ export function applyCustomRules(md: MarkdownIt): MarkdownIt {
     // <hr>
     {
       name: 'hr',
-      rule: renderRule('mt-6 border-gray-600'),
+      rule: renderRule('mt-6 border-grey-500'),
     },
     // <a>
     {

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -5,6 +5,7 @@
  ** Default: https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
  */
 import { colors, opacity } from 'tailwindcss/defaultTheme'
+import palette from 'material-colors'
 
 const lime = {
   light: '#ffff6c',
@@ -30,9 +31,10 @@ module.exports = {
         amber: amber,
         primary: amber,
         secondary: cyan,
-        background: '#efebe9',
+        background: palette.grey[200], // gray = grey
         surface: '#efebe9',
         error: '#B00020',
+        ...palette,
       },
       opacity: {
         '15': '0.15',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,6 +6564,11 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+material-colors@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
+  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
+
 material-components-web@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/material-components-web/-/material-components-web-6.0.0.tgz#cae2924e16c77fcdae6d5d472bcb0280a7e3d6e8"


### PR DESCRIPTION
マテリアルデザイン用カラーパレットを提供する `material-colors` ライブラリを用いて色指定を行うように修正。

- chore: install material-colors
- fix: overwrite to material colors in tailwindcss
- fix: fix color to grey from gray
- fix: fix colors in tag chips
- fix: fix color to primary
- fix: fix a link range
- fix: fix color to use tailwindcss

close #79