### PR TITLE
feat: 前後記事へのナビゲーション実装

### DIFF
--- a/src/components/atoms/LinkWrapper.vue
+++ b/src/components/atoms/LinkWrapper.vue
@@ -2,13 +2,18 @@
   <a
     v-if="props.href.match(/^https?:\/\//) != null"
     class="link"
-    v-bind:class="{ disabled: props.disabled }"
+    v-bind:class="[{ disabled: props.disabled }, data.class, data.staticClass]"
     v-bind:href="props.href"
     target="_blank"
   >
     <slot></slot>
   </a>
-  <nuxt-link v-else v-bind:to="props.href" class="link" v-bind:class="{ disabled: props.disabled }">
+  <nuxt-link
+    v-else
+    v-bind:to="props.href"
+    class="link"
+    v-bind:class="[{ disabled: props.disabled }, data.class, data.staticClass]"
+  >
     <slot></slot>
   </nuxt-link>
 </template>

--- a/src/components/organisms/ArticlePagination.spec.ts
+++ b/src/components/organisms/ArticlePagination.spec.ts
@@ -1,0 +1,65 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import ArticlePagination from './ArticlePagination.vue'
+import { ArticleNavigation } from '@/models'
+
+describe('ArticlePagination', () => {
+  test.each([
+    [
+      {
+        next: { path: '', title: '' },
+        prev: { path: '/foo', title: 'foofoo' },
+      },
+      {
+        next: true,
+        prev: false,
+      },
+    ],
+    [
+      { next: { path: '', title: '' }, prev: { path: '', title: '' } },
+      {
+        next: true,
+        prev: true,
+      },
+    ],
+    [
+      {
+        next: { path: '/posts/hoge', title: 'sample_hoge' },
+        prev: { path: '/posts/bar', title: 'sample_bar' },
+      },
+      {
+        next: false,
+        prev: false,
+      },
+    ],
+    [
+      {
+        next: { path: '/sample/test/bar', title: 'sample_bar' },
+        prev: { path: '', title: '' },
+      },
+      {
+        next: false,
+        prev: true,
+      },
+    ],
+  ])('navigation disabled status', (navi: ArticleNavigation, expected) => {
+    const wrapper = shallowMount(ArticlePagination, {
+      propsData: { navigation: navi },
+      stubs: { NuxtLink: true },
+    })
+
+    //console.log(wrapper.html())
+
+    expect(
+      wrapper
+        .find(`nuxtlink-stub[to="${navi.next.path}"]`)
+        .classes()
+        .includes('disabled')
+    ).toBe(expected.next)
+    expect(
+      wrapper
+        .find(`nuxtlink-stub[to="${navi.prev.path}"]`)
+        .classes()
+        .includes('disabled')
+    ).toBe(expected.prev)
+  })
+})

--- a/src/components/organisms/ArticlePagination.vue
+++ b/src/components/organisms/ArticlePagination.vue
@@ -1,0 +1,61 @@
+<template functional>
+  <ul
+    class="grid grid-cols-2 gap-12 border-t border-b border-grey-500 py-2"
+    v-bind:class="[data.class, data.staticClass]"
+  >
+    <!-- 次の記事 -->
+    <li
+      class="flex items-center justify-end"
+      v-bind:class="{'text-grey-500 text-opacity-87': props.navigation.next.path.isEmpty()}"
+    >
+      <component
+        class="inline-flex justify-center px-4"
+        v-bind:is="injections.components.LinkWrapper"
+        v-bind:href="props.navigation.next.path"
+        v-bind:disabled="props.navigation.next.path.isEmpty()"
+      >
+        <template v-slot:default>
+          <span>{{ props.navigation.next.title }}</span>
+        </template>
+      </component>
+      <span class="material-icons transform rotate-180">double_arrow</span>
+    </li>
+    <!-- 前の記事 -->
+    <li
+      class="flex items-center fustify-start"
+      v-bind:class="{'text-grey-500 text-opacity-87': props.navigation.prev.path.isEmpty()}"
+    >
+      <span class="material-icons">double_arrow</span>
+      <component
+        class="inline-flex justify-center px-4"
+        v-bind:is="injections.components.LinkWrapper"
+        v-bind:href="props.navigation.prev.path"
+        v-bind:disabled="props.navigation.prev.path.isEmpty()"
+      >
+        <template v-slot:default>
+          <span>{{ props.navigation.prev.title }}</span>
+        </template>
+      </component>
+    </li>
+  </ul>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Inject } from 'nuxt-property-decorator'
+import { ArticlePageProps, ArticleNavigation } from '../../models'
+import '../../helpers/string.extension'
+import LinkWrapper from '../atoms/LinkWrapper.vue'
+
+@Component({})
+export default class ArticlePagination extends Vue
+  implements ArticlePageProps.NavigationProp {
+  @Prop({ required: true }) navigation!: ArticleNavigation
+
+  @Inject({ default: { LinkWrapper } }) components!: {
+    [key: string]: typeof Vue
+  }
+}
+</script>
+
+<style lang="scss">
+</style>

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -1,33 +1,43 @@
 <template>
-  <div>
+  <div class="pb-6">
     <HeadingLevel v-bind:value="headingLevel" />
     <div class="mt-4">
       <TagColumn v-bind:tags="tags" v-on:click="onClickTag" />
-      <DatesDisplay
-        class="flex justify-end"
-        v-bind:item="article | dateFormats"
-      />
+      <DatesDisplay class="flex justify-end" v-bind:item="article | dateFormats" />
     </div>
+
     <hr class="mt-2 border-grey-500" />
+
     <!-- 要素テスト用 -->
     <div v-if="isDebug(article.tags)" class="flex mt-4">
       <ButtonMaterial />
       <ButtonMaterial class="ml-4" v-bind:property="{ label: 'hoge' }" />
       <ButtonMaterial class="ml-4" v-bind:property="{ type: 'outlined' }" />
-      <ButtonMaterial
-        class="ml-4"
-        v-bind:property="{ type: 'raised', icon: 'bookmark' }"
-      />
+      <ButtonMaterial class="ml-4" v-bind:property="{ type: 'raised', icon: 'bookmark' }" />
     </div>
     <!-- 要素テスト終了 -->
+
+    <!-- Markdown記事本文 -->
     <ArticleBody class="mt-6" v-bind:renderd="article.body" />
+
+    <!--
+      前後記事へのナビゲーション
+      作業途中・草案中の記事では表示しない。
+    -->
+    <ArticlePagination v-if="!isDebug(article.tags)" class="mt-8" v-bind:navigation="navigation" />
   </div>
 </template>
 
 <script lang="ts">
 import { Component, mixins, Prop, Vue } from 'nuxt-property-decorator'
 import moment from 'moment'
-import { Article, ArticleTag, HeadingLevelType } from '@/models'
+import {
+  Article,
+  ArticleNavigation,
+  ArticlePageProps,
+  ArticleTag,
+  HeadingLevelType,
+} from '@/models'
 import { DebugMixin } from '@/mixins/debugMixin'
 import { Content } from '*.md'
 
@@ -36,6 +46,7 @@ import DatesDisplay from '../molecules/DatesDisplay.vue'
 import HeadingLevel from '../atoms/HeadingLevel.vue'
 import TagColumn from '../molecules/TagColumn.vue'
 import ButtonMaterial from '../atoms/ButtonMaterial.vue'
+import ArticlePagination from '../organisms/ArticlePagination.vue'
 
 /**
  * _Markdown_ 記事テンプレート。
@@ -47,6 +58,7 @@ import ButtonMaterial from '../atoms/ButtonMaterial.vue'
 @Component({
   components: {
     ArticleBody,
+    ArticlePagination,
     DatesDisplay,
     HeadingLevel,
     TagColumn,
@@ -64,7 +76,8 @@ import ButtonMaterial from '../atoms/ButtonMaterial.vue'
     },
   },
 })
-export default class ArticlePosted extends mixins(DebugMixin) {
+export default class ArticlePosted extends mixins(DebugMixin)
+  implements ArticlePageProps.NavigationProp {
   /**
    * _Front Matter_ つきの _Markdown_ ファイルの内容。
    */
@@ -75,6 +88,8 @@ export default class ArticlePosted extends mixins(DebugMixin) {
     },
   })
   markdown!: Content
+
+  @Prop({ required: true }) navigation!: ArticleNavigation
 
   /**
    * `props` の `markdown` を `Article` 型へ変換する。

--- a/src/helpers/functions.spec.ts
+++ b/src/helpers/functions.spec.ts
@@ -1,4 +1,4 @@
-import { isObject, encodePathURI } from './functions'
+import { isObject, encodePathURI, naviArticleFrontBack } from './functions'
 
 describe('Functions', () => {
   test('of isObject', () => {
@@ -18,5 +18,54 @@ describe('Functions', () => {
     ['q=', 'q='],
   ])('does encodePathURI(%s)', (x, expected) => {
     expect(encodePathURI(x)).toEqual(expected)
+  })
+
+  test.each([
+    [
+      '/hoge',
+      [
+        { filename: 'hoge', title: 'hogehoge' },
+        { filename: 'foo', title: 'foofoo' },
+      ],
+      {
+        next: { path: '', title: '' },
+        prev: { path: '/foo', title: 'foofoo' },
+      },
+    ],
+    [
+      '/sample/hoge',
+      [{ filename: 'hoge', title: 'sample' }],
+      { next: { path: '', title: '' }, prev: { path: '', title: '' } },
+    ],
+    [
+      '/posts/foo',
+      [
+        { filename: 'huga', title: 'sample_huga' },
+        { filename: 'hoge', title: 'sample_hoge' },
+        { filename: 'foo', title: 'sample_foo' },
+        { filename: 'bar', title: 'sample_bar' },
+        { filename: 'fuga', title: 'sample_fuga' },
+      ],
+      {
+        next: { path: '/posts/hoge', title: 'sample_hoge' },
+        prev: { path: '/posts/bar', title: 'sample_bar' },
+      },
+    ],
+    [
+      '/sample/test/fuga',
+      [
+        { filename: 'huga', title: 'sample_huga' },
+        { filename: 'hoge', title: 'sample_hoge' },
+        { filename: 'foo', title: 'sample_foo' },
+        { filename: 'bar', title: 'sample_bar' },
+        { filename: 'fuga', title: 'sample_fuga' },
+      ],
+      {
+        next: { path: '/sample/test/bar', title: 'sample_bar' },
+        prev: { path: '', title: '' },
+      },
+    ],
+  ])('does naviArticleFrontBack(%s)', (route, names, expected) => {
+    expect(naviArticleFrontBack(route, names)).toEqual(expected)
   })
 })

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -1,3 +1,5 @@
+import { ArticleNavigation } from '../models'
+
 /**
  * 引数がオブジェクトか否かを判定する。
  *
@@ -22,4 +24,39 @@ export function encodePathURI(path: string): string {
   }
 
   return uri
+}
+
+/**
+ * 前の記事と次の記事へのリンクパスを返す。
+ *
+ * 現在ページのパスおよび記事ファイル名からリンクパスを生成する。
+ *
+ * @param routePath 現在のページのパス。
+ * @param files すべての記事ファイル名とタイトル。昇順ソート済みであること。
+ * @return `next` 次のリンク `prev`: 前のリンク
+ */
+export function naviArticleFrontBack(
+  routePath: string,
+  files: { filename: string; title: string }[]
+): ArticleNavigation {
+  const parentPath = routePath.split('/').slice(0, -1).join('/')
+  const currentFileName = routePath.split('/').slice(-1)[0]
+  const index = files.findIndex((x) => x.filename === currentFileName)
+
+  return {
+    next:
+      index - 1 < 0
+        ? { path: '', title: '' }
+        : {
+            path: [parentPath, files[index - 1]?.filename].join('/'),
+            title: files[index - 1].title,
+          },
+    prev:
+      index + 1 >= files.length
+        ? { path: '', title: '' }
+        : {
+            path: [parentPath, files[index + 1]?.filename].join('/'),
+            title: files[index + 1].title,
+          },
+  }
 }

--- a/src/mixins/debugMixin.ts
+++ b/src/mixins/debugMixin.ts
@@ -1,5 +1,11 @@
 import Vue from 'vue'
 
+export namespace DebugMixinMethod {
+  export function isDebug(tags: string[]) {
+    return ['WIP', 'draft'].some((x) => tags.includes(x))
+  }
+}
+
 /**
  * デバッグ用関数を提供する _Vue mixin_
  *
@@ -17,7 +23,7 @@ export const DebugMixin = Vue.extend({
      * @param tags 記事のタグ
      */
     isDebug(tags: string[]) {
-      return ['WIP', 'draft'].some((x) => tags.includes(x))
+      return DebugMixinMethod.isDebug(tags)
     },
   },
 })

--- a/src/models/article.ts
+++ b/src/models/article.ts
@@ -29,5 +29,29 @@ export interface Article {
   /**
    * その他情報
    */
-  readonly meta?: object
+  readonly meta?: { [key: string]: any }
+}
+
+/**
+ * 前の記事・次の記事へのリンクと記事タイトルを格納する。
+ *
+ * @property next - 次の記事
+ * @property prev - 前の記事
+ */
+export interface ArticleNavigation {
+  /**
+   * 次の記事のリンク先 `path` と記事のタイトル `title` を持つ。
+   */
+  readonly next: {
+    path: string
+    title: string
+  }
+
+  /**
+   * 前の記事のリンク先 `path` と記事のタイトル `title` を持つ。
+   */
+  readonly prev: {
+    path: string
+    title: string
+  }
 }

--- a/src/models/vueProperties.ts
+++ b/src/models/vueProperties.ts
@@ -1,5 +1,6 @@
 import { Paging } from './paging'
 import { PostFile } from './postFile'
+import { ArticleNavigation } from './article'
 
 /**
  * トップページに関わるプロパティをもつインタフェースを定義。
@@ -47,5 +48,20 @@ export namespace LinkProps {
      * 表示ページのルートパス。
      */
     route: string
+  }
+}
+
+/**
+ * 記事ページに関わるプロパティを定義するインタフェース。
+ */
+export namespace ArticlePageProps {
+  /**
+   * ナビゲーションについてのインタフェース。
+   */
+  export interface NavigationProp {
+    /**
+     * 前後記事へのナビゲーションリンク。
+     */
+    readonly navigation: ArticleNavigation
   }
 }

--- a/src/pages/posts/_slug/index.vue
+++ b/src/pages/posts/_slug/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <ArticlePosted v-bind:markdown="prop" />
+  <ArticlePosted v-bind:markdown="prop" v-bind:navigation="navi" />
 </template>
 
 <script lang="ts">
@@ -8,9 +8,13 @@ import fm from 'front-matter'
 import { Attribute, Content } from '*.md'
 import { posts } from '@/assets/markdowns/posts/postlist.json'
 import ArticlePosted from '@/components/templates/ArticlePosted.vue'
+import { naviArticleFrontBack } from '@/helpers/functions'
+import { ArticleNavigation } from '../../../models'
+import { DebugMixinMethod } from '@/mixins/debugMixin'
 
 type Property = {
   prop: Content
+  navi: ArticleNavigation
 }
 
 export default Vue.extend({
@@ -31,7 +35,16 @@ export default Vue.extend({
     )
     const post = fm<Attribute>(md.default)
 
-    //console.log(`params: ${context.params.slug}`)
+    const navi = naviArticleFrontBack(
+      context.route.path,
+      posts
+        .filter((x) => !DebugMixinMethod.isDebug(x.tags))
+        .map((x) => {
+          return { filename: x.filename_noext, title: x.title }
+        })
+    )
+
+    //console.log(`navi: { prev: ${navi.prev}, next: ${navi.next} }`)
 
     return {
       prop: {
@@ -39,6 +52,7 @@ export default Vue.extend({
         body: context.$markdownIt.render(post.body),
         frontMatter: post.frontmatter,
       },
+      navi: navi,
     }
   },
   mounted() {


### PR DESCRIPTION
記事ページに前後の記事へのリンクを提供するナビゲーションを実装。
草案中の記事では非表示かつリンク先に含めない。

- feat: add function of navigation article link
- fix: fix to merge class from parent
- feat: add article pagination
- fix: exclude draft articles on pagination

close #76