### PR TITLE
feat: シェアボタンを作成

### DIFF
--- a/src/components/atoms/ButtonMaterialIcon.spec.ts
+++ b/src/components/atoms/ButtonMaterialIcon.spec.ts
@@ -1,0 +1,57 @@
+import { shallowMount } from '@vue/test-utils'
+import ButtonMaterialIcon from './ButtonMaterialIcon.vue'
+
+describe('ButtonMaterialIcon', () => {
+  test('is Material Icon Button', () => {
+    const wrapper = shallowMount(ButtonMaterialIcon, {
+      slots: {
+        default: '<svg><span>sample</span></svg>',
+      },
+    })
+
+    expect(wrapper.contains('.mdc-icon-button')).toBeTruthy()
+    expect(wrapper.find('svg').exists()).toBeTruthy()
+  })
+
+  test.each([
+    ['https://sample.com', false, 'a[href]', false],
+    ['https://sample.com', true, 'a[href]', true],
+    ['', false, 'button:not([href])', false],
+    [undefined, true, 'button:not([href])', true],
+  ])('change root tag or disabled', (href, disabled, tag, isDisabled) => {
+    const w = shallowMount(ButtonMaterialIcon, {
+      propsData: {
+        href: href,
+        isDisabled: disabled,
+      },
+      slots: {
+        default: '<svg><span>sample</span></svg>',
+      },
+    })
+
+    //console.log(w.html())
+
+    expect(w.contains(tag)).toBeTruthy()
+    expect(w.find('.disabled').exists()).toBe(isDisabled)
+  })
+
+  test.each([[['hoge']], [[1, 2, 3]]])('does click(%s)', (args: any[]) => {
+    const mockFn = jest.fn((x) => x)
+    const w = shallowMount(ButtonMaterialIcon, {
+      propsData: {
+        href: '',
+        args: args,
+      },
+      listeners: {
+        click: (...arg: any) => mockFn(arg),
+      },
+      slots: {
+        default: '<span class="material-icon">sample</span>',
+      },
+    })
+
+    w.find('button').trigger('click')
+    expect(mockFn.mock.calls.length).toBe(1)
+    expect(mockFn.mock.calls[0][0]).toEqual(args)
+  })
+})

--- a/src/components/atoms/ButtonMaterialIcon.vue
+++ b/src/components/atoms/ButtonMaterialIcon.vue
@@ -1,0 +1,65 @@
+<template functional>
+  <div>
+    <div
+      v-bind:is="props.href.isEmpty() ? 'button' : 'a'"
+      class="material-icons mdc-icon-button"
+      v-bind:class="[{ disabled: props.isDisabled }, data.class, data.staticClass]"
+      v-bind:href="props.href.isNotEmpty() ? props.href : false"
+      v-bind:target="props.href.isNotEmpty() ? '_blank' : false"
+      v-on:click="props.href.isEmpty() ? listeners.click(...props.args) : () => ''"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import '@/helpers/string.extension'
+
+/**
+ * アイコンカラーは `--mdc-theme-text-primary-on-background` に準じる。
+ */
+@Component
+export default class ButtonMaterialIcon extends Vue {
+  /**
+   * URLリンクを格納するプロパティで、この値が空文字でなければアイコンボタンを `<a>` タグとして機能させる。
+   */
+  @Prop({ required: false, default: '' }) href?: string
+
+  /**
+   * ボタン機能の無効化。デフォルトでは `false` 。
+   */
+  @Prop({ required: false, default: false }) isDisabled?: boolean
+
+  /**
+   * clickイベントに渡す引数
+   */
+  @Prop({ required: false }) args?: any[]
+}
+</script>
+
+<style lang="scss" scoped>
+@use "@material/icon-button";
+
+@include icon-button.core-styles;
+
+// 親要素のサイズに合わせる。
+// カラーは `--mdc-theme-text-primary-on-background` を参照。
+.mdc-icon-button {
+  font-size: 1em;
+  width: 100%;
+  height: 100%;
+  padding: min(0px, calc((100% - #{icon-button.$icon-size}) / 2));
+
+  color: var(--mdc-theme-text-primary-on-background);
+
+  &.disabled {
+    --mdc-theme-text-primary-on-background: var(
+      --mdc-theme-text-disabled-on-light
+    );
+
+    pointer-events: none;
+  }
+}
+</style>

--- a/src/components/atoms/SvgImage.spec.ts
+++ b/src/components/atoms/SvgImage.spec.ts
@@ -2,27 +2,20 @@ import { shallowMount } from '@vue/test-utils'
 import SvgImage from './SvgImage.vue'
 
 describe('SvgImage', () => {
-  const createWrapper = (
-    size?: number,
-    title: string = 'Sample',
-    path: string = 'dummy'
-  ) =>
+  const createWrapper = (title: string = 'Sample', path: string = 'dummy') =>
     shallowMount(SvgImage, {
       propsData: {
         title: title,
         svgPath: path,
-        size: size,
       },
     })
 
   test.each([
-    [24, '0 0 24 24'],
-    [undefined, '0 0 24 24'],
-    [32, '0 0 32 32'],
-    [128, '0 0 128 128'],
-  ])('size(%s) to viewBox(%s)', (size, view) => {
-    expect(createWrapper(size).find('svg[viewBox]').attributes().viewBox).toBe(
-      view
-    )
+    ['sample', '0 1 2 3'],
+    ['hello world', 'M23.954 4.569c-.885.389-1.83.654-2.825.775 1.014-.611'],
+  ])('svg title(%s), path(%s)', (title, path) => {
+    const wrapper = createWrapper(title, path)
+    expect(wrapper.find('title').text()).toBe(title)
+    expect(wrapper.find('path').attributes().d).toBe(path)
   })
 })

--- a/src/components/atoms/SvgImage.vue
+++ b/src/components/atoms/SvgImage.vue
@@ -3,7 +3,7 @@
     class="fill-current"
     v-bind:class="[data.staticClass, data.class]"
     role="img"
-    v-bind:viewBox="$options.methods.viewBox(props.size)"
+    viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
     <title>{{ props.title }}</title>
@@ -25,15 +25,6 @@ export default class SvgImage extends Vue implements SvgOption {
   @Prop({ required: true }) title!: string
 
   @Prop({ required: true }) svgPath!: string
-
-  @Prop({ required: false, default: 24 }) size?: number
-
-  /**
-   * `viewBox` の値を返す。`
-   */
-  viewBox(size: number) {
-    return `0 0 ${size} ${size}`
-  }
 }
 </script>
 

--- a/src/components/atoms/SvgImageConcretes/SvgIconName.html
+++ b/src/components/atoms/SvgImageConcretes/SvgIconName.html
@@ -2,6 +2,5 @@
   v-bind:is="injections.components.SvgImage"
   v-bind:class="[data.staticClass, data.class]"
   v-bind:title="props.title"
-  v-bind:size="props.size"
   v-bind:svgPath="$options.methods.svgPath()"
 />

--- a/src/components/atoms/SvgImageConcretes/SvgImageConcreter.spec.ts
+++ b/src/components/atoms/SvgImageConcretes/SvgImageConcreter.spec.ts
@@ -2,17 +2,18 @@ import { shallowMount } from '@vue/test-utils'
 import Vue from 'vue'
 import SvgImageTwitter from './SvgImageTwitter.vue'
 import SvgImageGithub from './SvgImageGithub.vue'
+import SvgImageFacebook from './SvgImageFacebook.vue'
+import SvgImagePocket from './SvgImagePocket.vue'
 
 describe('Concrete SvgImage', () => {
-  const createWrapper = (
-    vue: typeof Vue,
-    title: string = 'sample',
-    size?: number
-  ) => shallowMount(vue, { propsData: { title: title, size: size } })
+  const createWrapper = (vue: typeof Vue, title: string = 'sample') =>
+    shallowMount(vue, { propsData: { title: title } })
 
   test.each([
     ['SvgImageTwitter', SvgImageTwitter],
     ['SvgISvgImageGithub', SvgImageGithub],
+    ['SvgISvgImageFacebook', SvgImageFacebook],
+    ['SvgISvgImagePocket', SvgImagePocket],
   ])('%s is a <svg> element', (name, vue) => {
     expect(createWrapper(vue).is('svg')).toBeTruthy()
   })

--- a/src/components/atoms/SvgImageConcretes/SvgImageFacebook.vue
+++ b/src/components/atoms/SvgImageConcretes/SvgImageFacebook.vue
@@ -1,0 +1,11 @@
+<template functional src="./SvgIconName.html"></template>
+
+<script lang="ts">
+import Icon from 'simple-icons/icons/facebook.js'
+import { SvgImageFactory } from './svgImageFactory'
+
+export default SvgImageFactory(Icon)
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/atoms/SvgImageConcretes/SvgImagePocket.vue
+++ b/src/components/atoms/SvgImageConcretes/SvgImagePocket.vue
@@ -1,0 +1,11 @@
+<template functional src="./SvgIconName.html"></template>
+
+<script lang="ts">
+import Icon from 'simple-icons/icons/pocket.js'
+import { SvgImageFactory } from './svgImageFactory'
+
+export default SvgImageFactory(Icon)
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/atoms/SvgImageConcretes/index.ts
+++ b/src/components/atoms/SvgImageConcretes/index.ts
@@ -1,2 +1,4 @@
 export { default as SvgImageGithub } from './SvgImageGithub.vue'
 export { default as SvgImageTwitter } from './SvgImageTwitter.vue'
+export { default as SvgImageFacebook } from './SvgImageFacebook.vue'
+export { default as SvgImagePocket } from './SvgImagePocket.vue'

--- a/src/components/atoms/SvgImageConcretes/svgImageFactory.spec.ts
+++ b/src/components/atoms/SvgImageConcretes/svgImageFactory.spec.ts
@@ -8,21 +8,16 @@ describe('SvgImageFactory', () => {
     hex: 'ffffff',
   }
 
-  test.each([[icon, 'sample', '48']])(
-    'create Vue instance',
-    (x, title, size) => {
-      const wrapper = shallowMount(SvgImageFactory(x), {
-        propsData: { title: title, size: size },
-        template: `<div>
+  test.each([[icon, 'sample']])('create Vue instance', (x, title) => {
+    const wrapper = shallowMount(SvgImageFactory(x), {
+      propsData: { title: title },
+      template: `<div>
         <span class="title">{{ title }}</span>
-        <span class="size">{{ size }}</span>
         <span class="path">{{ svgPath() }}</span>
         </div>`,
-      })
+    })
 
-      expect(wrapper.find('.title').text()).toBe(title)
-      expect(wrapper.find('.size').text()).toBe(size)
-      expect(wrapper.find('.path').text()).toBe(icon.path)
-    }
-  )
+    expect(wrapper.find('.title').text()).toBe(title)
+    expect(wrapper.find('.path').text()).toBe(icon.path)
+  })
 })

--- a/src/components/atoms/SvgImageConcretes/svgImageFactory.ts
+++ b/src/components/atoms/SvgImageConcretes/svgImageFactory.ts
@@ -12,8 +12,6 @@ import SvgImage from '../SvgImage.vue'
  *
  * - `title` SVG画像のタイトル名。
  *
- * - `size` 描画領域のサイズ（デフォルト `24`）。
- *
  * @param icon `simple-icons` からのインポート
  */
 export const SvgImageFactory = (
@@ -22,8 +20,6 @@ export const SvgImageFactory = (
   @Component
   class Factory extends Vue implements SvgSpecificComponent {
     @Prop({ required: true }) title!: string
-
-    @Prop({ required: false, default: 24 }) size?: number
 
     svgPath() {
       return icon.path

--- a/src/components/molecules/ShareButton/ShareButtonFacebook.vue
+++ b/src/components/molecules/ShareButton/ShareButtonFacebook.vue
@@ -1,0 +1,29 @@
+<template functional src="./ShareButtonIcon.html"></template>
+
+<script lang="ts">
+import { Component, mixins, Prop, Inject } from 'nuxt-property-decorator'
+import { shareButtonFactory, ShareButtonInterface } from './ShareButtonFactory'
+import { SvgImageFacebook as SvgIcon } from '../../atoms/SvgImageConcretes'
+import ButtonMaterialIcon from '../../atoms/ButtonMaterialIcon.vue'
+
+@Component
+export default class ShareButtonFacebook
+  extends mixins(shareButtonFactory('facebook'))
+  implements ShareButtonInterface {
+  /**
+   * SVG画像につけるタイトル。
+   */
+  @Prop({ required: false, default: 'Share' }) title?: string
+
+  // 使用するVueコンポーネントを注入
+  @Inject({ default: { ButtonMaterialIcon, SvgIcon } })
+  components!: any
+}
+</script>
+
+<style lang="scss" scoped>
+.share-button {
+  --mdc-theme-text-primary-on-background: var(--md-white);
+  background-color: #1877f2;
+}
+</style>

--- a/src/components/molecules/ShareButton/ShareButtonFactory.spec.ts
+++ b/src/components/molecules/ShareButton/ShareButtonFactory.spec.ts
@@ -1,0 +1,64 @@
+import { shallowMount } from '@vue/test-utils'
+import Vue from 'vue'
+import { shareButtonFactory, ShareType } from './ShareButtonFactory'
+
+describe('ShareButtonFactory', () => {
+  const templateSample = `<div>
+      <span class="url">{{ url }}</span>
+      <span class="text">{{ text }}</span>
+      <span class="shareFullURL">{{ shareFullURL(url, text) }}</span>
+      </div>`
+  const createWrapper = (
+    vue: typeof Vue,
+    url = 'https://sample.com',
+    text = 'sample',
+    template = templateSample
+  ) =>
+    shallowMount(vue, {
+      propsData: {
+        url: url,
+        text: text,
+      },
+      template: template,
+    })
+
+  test('create Vue component', () => {
+    const component = shareButtonFactory('twitter')
+    const wrapper = createWrapper(component)
+
+    expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+
+  test.each<[ShareType, string, string, string]>([
+    [
+      'twitter',
+      'https://sample.com',
+      'sample text',
+      'https://twitter.com/intent/tweet?text=sample+text&url=https%3A%2F%2Fsample.com',
+    ],
+    [
+      'facebook',
+      'https://sample.com/hogehoge',
+      '',
+      'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsample.com%2Fhogehoge',
+    ],
+    [
+      'pocket',
+      'https://sample.com',
+      '',
+      'https://getpocket.com/edit?url=https%3A%2F%2Fsample.com',
+    ],
+    ['url', 'https://sample.com/link', '', 'https://sample.com/link'],
+  ])('each url of %s', (sns, url, text, result) => {
+    const component = shareButtonFactory(sns)
+    const wrapper = createWrapper(component, url, text)
+    expect(wrapper.find('.shareFullURL').text()).toBe(result)
+  })
+
+  test.each(['wrong', 'missing', 'notfound'])('wrong sns type', (sns) => {
+    const spy = spyOn(console, 'error')
+
+    const component = shareButtonFactory(sns as ShareType)
+    expect(() => createWrapper(component)).toThrowError()
+  })
+})

--- a/src/components/molecules/ShareButton/ShareButtonFactory.ts
+++ b/src/components/molecules/ShareButton/ShareButtonFactory.ts
@@ -1,0 +1,116 @@
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+/**
+ * SNSでシェアするための共通コンポーネント。
+ *
+ * ## Props
+ *
+ * - `url` string
+ * - `text` string?
+ *
+ * ## Methods
+ *
+ * - `shareFullURL(url, text)`
+ *
+ */
+export interface ShareButtonInterface {
+  /**
+   * ページタイトルを想定。
+   */
+  readonly text?: string
+
+  /**
+   * そのページURL。
+   */
+  readonly url: string
+
+  /**
+   * SNSのシェア用URL（パラメータを含む）を生成して返す。
+   *
+   * @param url シェア対象であるページのURL
+   * @param text Twitter用の自動挿入する文章。主にページタイトル。
+   */
+  shareFullURL(url: string, text?: string): string
+}
+
+/**
+ * シェアするSNSの種類。
+ * `url` は `TEXT: PAGE_URL` のフォーマットを返す。
+ */
+export type ShareType = 'twitter' | 'facebook' | 'pocket' | 'url'
+
+// シェア用の基本URLとクエリパラメータを生成する関数を含む
+interface ShareLink {
+  base: string
+  query(url: string, text?: string): URLSearchParams
+}
+
+/**
+ * SNSの種類ごとのシェアボタン用の _Vue Mixin_ を生成する関数。
+ *
+ * @param type 各SNSの種類。
+ */
+export function shareButtonFactory(type: ShareType) {
+  // 各SNSごとのクエリを生成する関数を返す
+  const queryCreateMap = new Map<ShareType, ShareLink>([
+    [
+      'twitter',
+      {
+        base: 'https://twitter.com/intent/tweet',
+        query: (url, text) => new URLSearchParams(`text=${text}&url=${url}`),
+      },
+    ],
+    [
+      'facebook',
+      {
+        base: 'https://www.facebook.com/sharer/sharer.php',
+        query: (url) => new URLSearchParams(`u=${url}`),
+      },
+    ],
+    [
+      'pocket',
+      {
+        base: 'https://getpocket.com/edit',
+        query: (url) => new URLSearchParams(`url=${url}`),
+      },
+    ],
+    [
+      'url',
+      {
+        base: '',
+        query: (url) => new URLSearchParams(),
+      },
+    ],
+  ])
+
+  // {type} SNS のシェア用URL
+  const share = queryCreateMap.get(type)
+
+  @Component
+  class ShareButton extends Vue implements ShareButtonInterface {
+    @Prop({
+      required: false,
+    })
+    text?: string
+
+    @Prop({
+      required: true,
+    })
+    url!: string
+
+    shareFullURL(url: string, text?: string): string {
+      if (share == null) {
+        throw new Error(`Wrong share type: ${type}`)
+      }
+
+      if (type === 'url') {
+        return url
+      }
+
+      const param = share.query(url, text)
+      return `${share.base}?${param.toString()}`
+    }
+  }
+
+  return ShareButton
+}

--- a/src/components/molecules/ShareButton/ShareButtonIcon.html
+++ b/src/components/molecules/ShareButton/ShareButtonIcon.html
@@ -1,0 +1,20 @@
+<div>
+  <div
+    class="share-button"
+    v-bind:class="[data.staticClass, data.class]"
+    rel="nofollow"
+  >
+    <component
+      v-bind:is="injections.components.ButtonMaterialIcon"
+      class="w-full h-full"
+      v-bind:href="$options.methods.shareFullURL(props.url, props.text)"
+      v-bind:args="[props.url]"
+      v-on:click="$options.methods.onClick"
+    >
+      <component
+        v-bind:is="injections.components.SvgIcon"
+        v-bind:title="props.title"
+      />
+    </component>
+  </div>
+</div>

--- a/src/components/molecules/ShareButton/ShareButtonIcon.spec.ts
+++ b/src/components/molecules/ShareButton/ShareButtonIcon.spec.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils'
+import ShareButtonTwitter from './ShareButtonTwitter.vue'
+import ShareButtonLink from './ShareButtonLink.vue'
+import ShareButtonFacebook from './ShareButtonFacebook.vue'
+import ShareButtonPocket from './ShareButtonPocket.vue'
+
+describe('ShareButton icons', () => {
+  test.each([
+    ['twitter', ShareButtonTwitter, 'Share sample'],
+    ['link', ShareButtonLink, 'copy url'],
+    ['facebook', ShareButtonFacebook, 'facebook'],
+    ['pocket', ShareButtonPocket, 'save'],
+  ])('%s share button', (sns, component, title) => {
+    const wrapper = mount(component, {
+      propsData: {
+        url: 'https://sample.com/post/page1',
+        text: 'Sample Data',
+        title: title,
+      },
+    })
+
+    if (sns !== 'link') {
+      expect(wrapper.find(`a[href*=${sns}] svg`).exists()).toBeTruthy()
+      expect(wrapper.find('svg title').text()).toBe(title)
+    } else {
+      //console.log(wrapper.html())
+      expect(wrapper.find('button').exists()).toBeTruthy()
+      //wrapper.find('button').trigger('click')
+    }
+  })
+})

--- a/src/components/molecules/ShareButton/ShareButtonLink.vue
+++ b/src/components/molecules/ShareButton/ShareButtonLink.vue
@@ -1,0 +1,49 @@
+<template functional src="./ShareButtonIcon.html"></template>
+
+<script lang="ts">
+import { Component, mixins, Prop, Inject, Vue } from 'nuxt-property-decorator'
+import { shareButtonFactory, ShareButtonInterface } from './ShareButtonFactory'
+import { copyClipboardMixin } from '@/mixins/copyClipboardMixin'
+import ButtonMaterialIcon from '../../atoms/ButtonMaterialIcon.vue'
+
+// Material design Icon
+const SvgIcon = Vue.extend({
+  //template: '<span class="material-icons" v-bind:title="title">link</span>',
+  props: { title: { type: String, required: false } },
+  render: function render(createElement) {
+    return createElement(
+      'span',
+      {
+        class: 'material-icons',
+        attrs: { title: this.title },
+      },
+      'link'
+    )
+  },
+})
+
+@Component
+export default class ShareButtonTwitter
+  extends mixins(shareButtonFactory('url'), copyClipboardMixin)
+  implements ShareButtonInterface {
+  /**
+   * SVG画像につけるタイトル。
+   */
+  @Prop({ required: false, default: 'Copy url' }) title?: string
+
+  // 使用するVueコンポーネントを注入
+  @Inject({ default: { ButtonMaterialIcon, SvgIcon } })
+  components!: any
+
+  shareFullURL(url: string) {
+    return ''
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.share-button {
+  --mdc-theme-text-primary-on-background: var(--md-white);
+  background-color: var(--md-grey-700);
+}
+</style>

--- a/src/components/molecules/ShareButton/ShareButtonPocket.vue
+++ b/src/components/molecules/ShareButton/ShareButtonPocket.vue
@@ -1,0 +1,29 @@
+<template functional src="./ShareButtonIcon.html"></template>
+
+<script lang="ts">
+import { Component, mixins, Prop, Inject } from 'nuxt-property-decorator'
+import { shareButtonFactory, ShareButtonInterface } from './ShareButtonFactory'
+import { SvgImagePocket as SvgIcon } from '../../atoms/SvgImageConcretes'
+import ButtonMaterialIcon from '../../atoms/ButtonMaterialIcon.vue'
+
+@Component
+export default class ShareButtonPocket
+  extends mixins(shareButtonFactory('pocket'))
+  implements ShareButtonInterface {
+  /**
+   * SVG画像につけるタイトル。
+   */
+  @Prop({ required: false, default: 'Save' }) title?: string
+
+  // 使用するVueコンポーネントを注入
+  @Inject({ default: { ButtonMaterialIcon, SvgIcon } })
+  components!: any
+}
+</script>
+
+<style lang="scss" scoped>
+.share-button {
+  --mdc-theme-text-primary-on-background: var(--md-white);
+  background-color: #ef3f56;
+}
+</style>

--- a/src/components/molecules/ShareButton/ShareButtonTwitter.vue
+++ b/src/components/molecules/ShareButton/ShareButtonTwitter.vue
@@ -1,0 +1,29 @@
+<template functional src="./ShareButtonIcon.html"></template>
+
+<script lang="ts">
+import { Component, mixins, Prop, Inject } from 'nuxt-property-decorator'
+import { shareButtonFactory, ShareButtonInterface } from './ShareButtonFactory'
+import { SvgImageTwitter as SvgIcon } from '../../atoms/SvgImageConcretes'
+import ButtonMaterialIcon from '../../atoms/ButtonMaterialIcon.vue'
+
+@Component
+export default class ShareButtonTwitter
+  extends mixins(shareButtonFactory('twitter'))
+  implements ShareButtonInterface {
+  /**
+   * SVG画像につけるタイトル。
+   */
+  @Prop({ required: false, default: 'Share tweet' }) title?: string
+
+  // 使用するVueコンポーネントを注入
+  @Inject({ default: { ButtonMaterialIcon, SvgIcon } })
+  components!: any
+}
+</script>
+
+<style lang="scss" scoped>
+.share-button {
+  --mdc-theme-text-primary-on-background: var(--md-white);
+  background-color: #1da1f2;
+}
+</style>

--- a/src/components/molecules/ShareButton/index.ts
+++ b/src/components/molecules/ShareButton/index.ts
@@ -1,0 +1,5 @@
+export * from './ShareButtonFactory'
+export { default as ShareButtonTwitter } from './ShareButtonTwitter.vue'
+export { default as ShareButtonFacebook } from './ShareButtonFacebook.vue'
+export { default as ShareButtonPocket } from './ShareButtonPocket.vue'
+export { default as ShareButtonLink } from './ShareButtonLink.vue'

--- a/src/components/organisms/ShareButtonsBar.spec.ts
+++ b/src/components/organisms/ShareButtonsBar.spec.ts
@@ -1,0 +1,14 @@
+import { shallowMount } from '@vue/test-utils'
+import ShareButtonsBar from './ShareButtonsBar.vue'
+
+describe('ShareButtonsBar', () => {
+  test('is 4 list', () => {
+    const w = shallowMount(ShareButtonsBar, {
+      propsData: {
+        url: 'https://sample.com',
+      },
+    })
+
+    expect(w.findAll('li.share-button').length).toBe(4)
+  })
+})

--- a/src/components/organisms/ShareButtonsBar.vue
+++ b/src/components/organisms/ShareButtonsBar.vue
@@ -1,0 +1,51 @@
+<template>
+  <ul class="flex">
+    <li class="share-button ml-4 first:ml-0" v-for="item of components" v-bind:key="item.id">
+      <component
+        v-bind:is="item.component"
+        class="rounded-md w-10 h-10 p-2"
+        v-bind:url="url"
+        v-bind:text="text"
+      />
+    </li>
+  </ul>
+</template>
+
+<script lang="ts">
+import { Component, Inject, Prop, Vue } from 'nuxt-property-decorator'
+import {
+  ShareButtonInterface,
+  ShareButtonFacebook,
+  ShareButtonLink,
+  ShareButtonPocket,
+  ShareButtonTwitter,
+} from '../molecules/ShareButton'
+
+@Component
+export default class ShareButtonsBar extends Vue
+  implements Omit<ShareButtonInterface, 'shareFullURL'> {
+  @Prop({ required: true }) url!: string
+  @Prop({ required: false }) text?: string
+
+  /**
+   * 利用するシェアボタンのコンポーネント連想配列を返す。
+   */
+  get components(): { id: number; component: typeof Vue; selector: string }[] {
+    return [
+      { id: 0, component: ShareButtonTwitter, selector: '' },
+      { id: 1, component: ShareButtonFacebook, selector: '' },
+      { id: 2, component: ShareButtonPocket, selector: '' },
+      { id: 3, component: ShareButtonLink, selector: '' },
+    ]
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.share-button {
+  &:hover {
+    filter: brightness(1.2);
+    transition: all 100ms 0s ease-in;
+  }
+}
+</style>

--- a/src/components/templates/ArticlePosted.spec.ts
+++ b/src/components/templates/ArticlePosted.spec.ts
@@ -33,6 +33,7 @@ describe('ArticlePosted', () => {
           next: { path: '/sample/path/next', title: 'sample Next' },
           prev: { path: '/sample/path/prev', title: 'sample Prev' },
         },
+        currentFullPath: 'https://hogehoge.com',
       },
     })
   })
@@ -92,5 +93,9 @@ describe('ArticlePosted', () => {
       createdAt: '2020年04月22日',
       updatedAt: '2020年04月25日',
     })
+  })
+
+  test('Share button', () => {
+    expect(wrapper.find('sharebuttonsbar-stub').exists()).toBeTruthy()
   })
 })

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -3,10 +3,7 @@
     <HeadingLevel v-bind:value="headingLevel" />
     <div class="mt-4">
       <TagColumn v-bind:tags="tags" v-on:click="onClickTag" />
-      <DatesDisplay
-        class="flex justify-end"
-        v-bind:item="article | dateFormats"
-      />
+      <DatesDisplay class="flex justify-end" v-bind:item="article | dateFormats" />
     </div>
 
     <hr class="mt-2 border-grey-500" />
@@ -16,25 +13,27 @@
       <ButtonMaterial />
       <ButtonMaterial class="ml-4" v-bind:property="{ label: 'hoge' }" />
       <ButtonMaterial class="ml-4" v-bind:property="{ type: 'outlined' }" />
-      <ButtonMaterial
-        class="ml-4"
-        v-bind:property="{ type: 'raised', icon: 'bookmark' }"
-      />
+      <ButtonMaterial class="ml-4" v-bind:property="{ type: 'raised', icon: 'bookmark' }" />
     </div>
     <!-- 要素テスト終了 -->
 
     <!-- Markdown記事本文 -->
     <ArticleBody class="mt-6" v-bind:renderd="article.body" />
 
+    <!-- シェアボタン -->
+    <div class="share-buttons mt-8">
+      <ShareButtonsBar
+        class="items-center justify-center"
+        v-bind:url="currentFullPath"
+        v-bind:text="article.title"
+      />
+    </div>
+
     <!--
       前後記事へのナビゲーション
       作業途中・草案中の記事では表示しない。
     -->
-    <ArticlePagination
-      v-if="!isDebug(article.tags)"
-      class="mt-8"
-      v-bind:navigation="navigation"
-    />
+    <ArticlePagination v-if="!isDebug(article.tags)" class="mt-6" v-bind:navigation="navigation" />
   </div>
 </template>
 
@@ -57,6 +56,7 @@ import HeadingLevel from '../atoms/HeadingLevel.vue'
 import TagColumn from '../molecules/TagColumn.vue'
 import ButtonMaterial from '../atoms/ButtonMaterial.vue'
 import ArticlePagination from '../organisms/ArticlePagination.vue'
+import ShareButtonsBar from '../organisms/ShareButtonsBar.vue'
 
 /**
  * _Markdown_ 記事テンプレート。
@@ -72,6 +72,7 @@ import ArticlePagination from '../organisms/ArticlePagination.vue'
     ArticlePagination,
     DatesDisplay,
     HeadingLevel,
+    ShareButtonsBar,
     TagColumn,
     ButtonMaterial,
   },
@@ -101,6 +102,11 @@ export default class ArticlePosted extends mixins(DebugMixin)
   markdown!: Content
 
   @Prop({ required: true }) navigation!: ArticleNavigation
+
+  /**
+   * 現在ページのフルパス。
+   */
+  @Prop({ required: true }) currentFullPath!: string
 
   /**
    * `props` の `markdown` を `Article` 型へ変換する。

--- a/src/mixins/copyClipboardMixin.spec.ts
+++ b/src/mixins/copyClipboardMixin.spec.ts
@@ -1,0 +1,16 @@
+import { onClick } from './copyClipboardMixin'
+
+describe('copyClipboardMixin', () => {
+  test.each([
+    ['sample', true],
+    [5, true],
+    ['hoge', true],
+    [null, false],
+    [undefined, false],
+  ])('does onClick(%s)', (text, isNormal) => {
+    spyOn(console, 'error')
+    isNormal
+      ? expect(() => onClick(text)).not.toThrow()
+      : expect(() => onClick(text)).toThrowError()
+  })
+})

--- a/src/mixins/copyClipboardMixin.ts
+++ b/src/mixins/copyClipboardMixin.ts
@@ -1,0 +1,29 @@
+import Vue from 'vue'
+
+/**
+ * 引数をクリップボードにコピーする関数。
+ * 引数で `null | undefined` が渡されると `Error` を投げる。
+ *
+ * @param copyText コピーする文字列
+ */
+export function onClick(copyText: any) {
+  if (copyText == null) {
+    console.error('Undefined copy text!')
+    throw new Error('Argument is null.')
+  }
+
+  navigator.clipboard
+    ?.writeText(copyText.toString())
+    .then((_) => console.log(`Copied ${copyText}`))
+}
+
+/**
+ * 引数の文字列をクリップボードにコピーする関数 `onClick(copyText)` をメソッドとして提供する。
+ *
+ * クリックイベント用。
+ */
+export const copyClipboardMixin = Vue.extend({
+  methods: {
+    onClick,
+  },
+})

--- a/src/models/svgOption.ts
+++ b/src/models/svgOption.ts
@@ -13,11 +13,6 @@ export interface SvgOption {
    * SVG要素の `path`。図形のパス
    */
   readonly svgPath: string
-
-  /**
-   * 描画領域のサイズ。デフォルト `24`
-   */
-  readonly size?: number
 }
 
 /**

--- a/src/pages/posts/_slug/index.vue
+++ b/src/pages/posts/_slug/index.vue
@@ -1,5 +1,9 @@
 <template>
-  <ArticlePosted v-bind:markdown="prop" v-bind:navigation="navi" />
+  <ArticlePosted
+    v-bind:markdown="prop"
+    v-bind:navigation="navi"
+    v-bind:currentFullPath="currentPath"
+  />
 </template>
 
 <script lang="ts">
@@ -15,6 +19,7 @@ import { DebugMixinMethod } from '@/mixins/debugMixin'
 type Property = {
   prop: Content
   navi: ArticleNavigation
+  currentPath: string
 }
 
 export default Vue.extend({
@@ -53,6 +58,7 @@ export default Vue.extend({
         frontMatter: post.frontmatter,
       },
       navi: navi,
+      currentPath: context.route.fullPath,
     }
   },
   mounted() {

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -57,6 +57,7 @@ module.exports = {
     backgroundOpacity: ['responsive', 'hover', 'focus', 'even', 'odd'],
     textColor: ['responsive', 'hover', 'focus', 'visited'],
     textDecoration: ['responsive', 'hover', 'focus', 'group-hover'],
+    margin: ['responsive', 'first'],
   },
   plugins: [],
   purge: ['./**/*.html', './**/*.vue'],


### PR DESCRIPTION
各SNSのシェアボタンを記事ページに設置。

- fix: remove size property and vieBox method

    Size of `<svg>` is changed tailwind css.
    An attribute of `viewBox` isn't changed size.

- chore: add variants for margin

- feat: create a material icon button wrapper

- feat: add svg images for share buttons

- feat: create ShareButton factory function

- feat: create ShareButton icons

- feat: create a share buttons bar

- feat: add share buttons bar on article page

close #83