### PR TITLE
fix: fix to download LFS objects

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: checkout lfs objects
+        run: git lfs checkout
 
       - name: setup node
         uses: actions/setup-node@v1


### PR DESCRIPTION
_Github Actions_ でLFSオブジェクトの取得をするように修正。

fix #105