### PR TITLE
feat: separate css for markdown

### DIFF
--- a/src/components/organisms/ArticleBody.spec.ts
+++ b/src/components/organisms/ArticleBody.spec.ts
@@ -46,20 +46,22 @@ describe('ArticleBody', () => {
   })
 
   it('is render code with a note', () => {
-    const header = 'code-note'
-
     // コードブロック:
     expect(wrapper.contains('.language-ts')).toBeTruthy()
     expect(wrapper.contains('.language-js')).toBeTruthy()
-    expect(wrapper.findAll(`.${header}`).length).toEqual(3)
+    expect(wrapper.findAll('pre code[class*="language-"]').length).toEqual(3)
 
-    const codeblockHeades = wrapper.findAll(`.${header}[data-lang]`)
+    const codeblockHeades = wrapper.findAll(`pre code[data-lang]`)
     expect(codeblockHeades.length).toEqual(2)
     expect(
-      codeblockHeades.at(0).find(`.${header}`).attributes()['data-lang']
+      codeblockHeades.at(0).find('pre code[class*="language-"]').attributes()[
+        'data-lang'
+      ]
     ).toBe('hogehoge')
     expect(
-      codeblockHeades.at(1).find(`.${header}`).attributes()['data-lang']
+      codeblockHeades.at(1).find('pre code[class*="language-"]').attributes()[
+        'data-lang'
+      ]
     ).toBe('fugafuga')
 
     const text = `<h2>Without code block header</h2>
@@ -68,7 +70,7 @@ describe('ArticleBody', () => {
     const wrapper2 = shallowMount(ArticleBody, {
       propsData: { renderd: text },
     })
-    expect(wrapper2.contains(`.${header}`)).toBeFalsy()
+    expect(wrapper2.contains('pre code[class*="language-"]')).toBeTruthy()
     expect(wrapper2.contains('h2')).toBeTruthy()
   })
 })

--- a/src/components/organisms/ArticleBody.vue
+++ b/src/components/organisms/ArticleBody.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="markdown-body" v-html="body"></div>
+    <div class="markdown-body line-numbers" v-html="body"></div>
   </div>
 </template>
 
@@ -24,4 +24,127 @@ export default class ArticleBody extends Vue {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss">
+.markdown-body {
+  // Heading Level
+  h1 {
+    @apply text-4xl font-light;
+  }
+  h2 {
+    @apply text-3xl font-normal mt-8;
+  }
+  h3 {
+    @apply text-2xl font-semibold mt-6;
+  }
+  h4 {
+    @apply text-xl font-semibold mt-4;
+  }
+  h5 {
+    @apply text-lg font-semibold mt-4;
+  }
+  h6 {
+    @apply text-base font-semibold mt-4;
+  }
+
+  // Paragraph
+  p {
+    @apply mt-4;
+  }
+
+  // List
+  ul,
+  ol {
+    @apply pl-6 mt-4;
+  }
+  li {
+    @apply mt-2;
+
+    > ul,
+    > ol {
+      @apply pl-4 mt-0;
+    }
+  }
+  ul {
+    @apply list-disc;
+  }
+  ol {
+    @apply list-decimal;
+  }
+
+  // Table
+  table {
+    @apply table-auto border-collapse mt-4;
+  }
+  tr {
+    @apply border-b border-black border-opacity-50;
+
+    &:nth-of-type(even) {
+      @apply bg-primary-light bg-opacity-15;
+    }
+  }
+  th {
+    @apply px-4 py-3;
+  }
+  td {
+    @apply px-4 py-2;
+  }
+
+  // Blockquote
+  blockquote {
+    @apply border-l-4 border-primary border-opacity-54;
+    @apply text-black text-opacity-75 italic;
+    @apply pl-4;
+  }
+
+  hr {
+    @apply border-grey-500 mt-6;
+  }
+
+  a {
+    @apply text-indigo-500;
+
+    &:hover {
+      @apply underline;
+    }
+
+    &:visited {
+      @apply text-purple-800;
+    }
+  }
+
+  // Codes
+  pre,
+  code {
+    font-family: 'Roboto Mono', monospace;
+  }
+
+  // Inline Code
+  :not(pre) code {
+    @apply rounded-sm bg-primary bg-opacity-38;
+    @apply px-1;
+
+    color: rgb(var(--md-dark-text-primary-rgb));
+  }
+
+  // Code Block
+  pre {
+    @apply relative rounded mt-4;
+
+    &:not([data-lang]) {
+      @apply py-4 pr-6;
+    }
+  }
+  pre[data-lang] {
+    @apply pb-4;
+
+    &::before {
+      @apply text-primary-light text-opacity-54;
+      @apply border-b border-dashed border-opacity-50;
+      @apply -mt-2 mb-4 -ml-3;
+
+      content: attr(data-lang);
+      display: block;
+    }
+  }
+}
+</style>

--- a/src/plugins/markdown-it/index.ts
+++ b/src/plugins/markdown-it/index.ts
@@ -26,7 +26,8 @@ declare module '@nuxt/types' {
 /**
  * カスタムルール適用済み `markdown-it` オブジェクト。
  */
-export const mdIt = applyCustomRules(makeMarkdownItObject())
+export const mdIt = makeMarkdownItObject()
+// applyCustomRules(makeMarkdownItObject())
 
 // プラグイン実装
 const mdPlugin: Plugin = (context) => {

--- a/src/plugins/markdown-it/markdown-it.spec.ts
+++ b/src/plugins/markdown-it/markdown-it.spec.ts
@@ -21,9 +21,8 @@ describe('Markdown-it', () => {
 
     expect(doc.querySelectorAll('pre code').length).toBe(2)
     expect(doc.querySelectorAll('.language-ts').length).toBe(2)
-    expect(doc.querySelectorAll('.code-note').length).toBe(2)
 
-    const dataLangElems = doc.querySelectorAll('.code-note[data-lang]')
+    const dataLangElems = doc.querySelectorAll('pre code[data-lang]')
     expect(dataLangElems.length).toBe(1)
     expect(dataLangElems.item(0).getAttribute('data-lang')).toBe('sample')
   })


### PR DESCRIPTION
_Markdown_ 記事のスタイルについて、レンダラーに直接書き込むのではなく、CSSとして分離。

close #111