### PR TITLE
feat: AsciiDoc解析を行うモジュール作成

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,15 @@
         "plugin:@typescript-eslint/recommended",
         "prettier/@typescript-eslint"
       ]
+    },
+    {
+      "files": ["*.config.js", "**/modules/**/*.js"],
+      "env": { "node": true, "es6": true },
+      "parserOptions": {
+        "ecmaVersion": 2015,
+        "sourceType": "module",
+        "ecmaFeatures": { "modules": true }
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "test-ci": "jest --coverage false"
   },
   "dependencies": {
+    "@asciidoctor/core": "^2.2.0",
     "@nuxt/typescript-runtime": "^0.4.0",
     "@types/markdown-it": "^10.0.0",
     "@types/prismjs": "^1.16.1",
+    "fast-deep-equal": "^3.1.3",
     "front-matter": "^3.1.0",
     "markdown-it": "^10.0.0",
     "markdown-it-attrs": "^3.0.3",

--- a/src/modules/asciidocPresenter/index.js
+++ b/src/modules/asciidocPresenter/index.js
@@ -1,0 +1,62 @@
+// @ts-check
+import { join } from 'path'
+import * as utils from './utils'
+
+/**
+ * _AsciiDoc_ ファイルをNuxtビルド前にJSONファイルとして出力するモジュール。
+ *
+ * @type {import('@nuxt/types').Module<import('./models').ModuleOptions>}
+ */
+export default function AsciidocPresenter(moduleOptions) {
+  const options = {
+    // Nuxtの srcDir からの相対パス
+    source: 'outsides/asciidocs',
+    target: 'assets/_asciidocs/db',
+    summaryFilename: 'summary.json',
+    ...moduleOptions,
+  }
+  // ファイル一覧JSONファイルパス
+  const jsonFile = join(options.target, options.summaryFilename)
+
+  /**
+   * Nuxtビルド作業前に実行する処理。
+   *
+   * AsciiDocソースファイルの一覧をJSONとして出力する。
+   *
+   * @param {*} nuxt
+   * @param {*} buildOptions
+   */
+  // eslint-disable-next-line no-unused-vars
+  const beforeBuildHook = async (nuxt, buildOptions) => {
+    const files = await utils.fileList(options.source)
+    const parsings = utils.parseFiles(files, {
+      safe: 'secure',
+    })
+    const summaries = parsings.map(utils.convertToSummary)
+
+    await utils.mkdir(options.target, {
+      recursive: true,
+    })
+    await utils.outputSummaryJson(summaries, options.source, jsonFile)
+    // await utils.outputDiscreteJson(parsings, options.target)
+  }
+
+  // hookに登録。
+  this.nuxt.hook('builder:prepared', beforeBuildHook)
+
+  // pluginに必要な相対パスファイルを登録
+  this.addTemplate({
+    src: join(__dirname, 'utils/asciidoc.js'),
+    fileName: 'utils/asciidoc.js',
+  })
+
+  // plugin登録
+  // summary.json からAsciidocソースを取得して解析する
+  this.addPlugin({
+    src: join(__dirname, 'plugin.js'),
+    options: {
+      // srcDirからの相対パス
+      jsonFile: join('@', jsonFile),
+    },
+  })
+}

--- a/src/modules/asciidocPresenter/models.ts
+++ b/src/modules/asciidocPresenter/models.ts
@@ -1,0 +1,57 @@
+/**
+ * モジュールのオプション。
+ *
+ * @param {string} source 直下に AsciiDoc ファイルがあるディレクトリのパス
+ * @param {string} target JSONファイルを出力するディレクトリのパス
+ * @param {string=} summaryFilename AsciiDocファイル一覧を出力するJSONファイル名。デフォルト `_summary.json`
+ */
+export interface ModuleOptions {
+  source?: string
+  target?: string
+  summaryFilename?: string
+}
+
+/**
+ * @param {string} filename ファイル名
+ * @param {string} created_at 作成日
+ */
+export type AsciidocSummary = {
+  filename: string // 'target.adoc'
+  created_at: string // '2020-08-08 (created_at attribute)'
+}
+
+/**
+ * AsciiDocファイルを解析し、出力用JSONオブジェクトに変換した型
+ *
+ * @param {string} dir AsciiDocファイルのあるディレクトリパス
+ * @param {AsciidocSummary[]} list ファイル一覧の情報
+ */
+export interface AsciidocSummaryJson {
+  dir: string // '/path/to/asciidoc/dir'
+  list: AsciidocSummary[]
+}
+
+/**
+ * {@link AsciidocSummary} に加えてプロパティを追加。
+ *
+ * @param {string} filename ファイル名
+ * @param {string} created_at 作成日
+ * @param {string} rendered レンダリング済みコンテンツ
+ * @param {string} title ドキュメントタイトル
+ * @param {string[]} tags タグ。コンマ区切りの文字列を分割
+ * @param {?string} updated_at 更新日
+ * @param {?string} author 著作者
+ * @param {?string} description ドキュメントの説明
+ * @param {?string} revision 更新バージョン
+ * @param {?string} revision_remark 更新内容
+ */
+export interface AsciidocParsed extends AsciidocSummary {
+  rendered: string // '<div>...</div>'
+  title: string | import('@asciidoctor/core').Asciidoctor.Document.Title // 'Asciidoc Document Title'
+  tags: string[] // '["sample", "test"] (convert from tags attribute)'
+  updated_at?: string // '2020-08-10 (revision date)'
+  author?: string // 'akiakiS (author attribute)'
+  description?: string // 'Sample asciidoc (description attribute)'
+  revision?: string // '1.1 (revision number)'
+  revision_remark?: string // 'update comment (revision remark)'
+}

--- a/src/modules/asciidocPresenter/plugin.js
+++ b/src/modules/asciidocPresenter/plugin.js
@@ -1,0 +1,103 @@
+// @ts-check
+import { basename, extname, join } from 'path'
+import { parse } from './utils/asciidoc'
+// @ts-ignore
+import jsonData from '<%= options.jsonFile %>'
+
+/**
+ * AsciiDocファイルを解析したデータを提供するNuxtプラグインの処理をまとめたクラス。
+ */
+export class AsciidocPlugin {
+  /**
+   *
+   * @param {import('./models').AsciidocSummaryJson} summaryJson ファイル一覧データを含むオブジェクト
+   */
+  constructor(summaryJson) {
+    this.summaryJson = summaryJson
+  }
+
+  /**
+   * AsciiDocファイル一覧から指定されたファイル名を検索し、一致したファイルのパスを返す。
+   *
+   * @private
+   * @param {string} filename ファイル名
+   * @throws {Error} ファイル名が一覧になかった場合にエラーメッセージを投げる
+   * @returns {string} ファイル名が一致したファイルのパス
+   */
+  __findSummaryFromList(filename) {
+    const target = this.summaryJson.list.find(
+      (summary) =>
+        basename(summary.filename, extname(summary.filename)) ===
+        basename(filename, extname(filename))
+    )
+
+    if (target == null) {
+      throw new Error(`NotFound: target file "${filename}"`)
+    }
+
+    return join(this.summaryJson.dir, target.filename)
+  }
+
+  /**
+   * ファイル名からAsciidocファイルを取得し、解析して返す。
+   *
+   * @param {string} filename AsciiDocソースファイル名
+   * @throws {Error} Not found filename in summary path lists
+   * @returns {Promise<import('./models').AsciidocParsed>} AsciiDocの解析データを返す。
+   */
+  async loadFile(filename) {
+    const filepath = this.__findSummaryFromList(filename)
+
+    return parse(join(filepath), {
+      safe: 'secure',
+    })
+  }
+
+  /**
+   * AsciiDocファイル一覧から指定されたファイル名を散策し、存在すれば `true` を返す。
+   * @param {string} filename ファイル名
+   * @returns {boolean} 指定されたファイル名が一覧にあれば `true`
+   */
+  hasFile(filename) {
+    try {
+      this.__findSummaryFromList(filename)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+/**
+ * AsciiDocを解析して得られた {@link import('./models').AsciidocParsed} データやファイル一覧データを提供する {@link AsciidocPlugin} を context.app に注入する。
+ *
+ * ## Example
+ *
+ * ```markup
+ * <template>
+ *   <div class="asciidoc-main">
+ *     <h1>{{ content.title }}</h1>
+ *     <div class="asciidoc-body" v-html="content.rendered"></div>
+ *   </div>
+ * </template>
+ *
+ * <script>
+ * export default {
+ *   async validate(ctx) {
+ *     return ctx.app.$asciidoc.hasFile(ctx.params.slug)
+ *   },
+ *   async asyncData(ctx) {
+ *     const json = ctx.app.$asciidoc.summaryJson;
+ *     const content = await ctx.app.$asciidoc.loadFile(ctx.params.slug);
+ *     return { json: json, content };
+ *   }
+ * };
+ * </script>
+ * ```
+ *
+ * @type {import('@nuxt/types').Plugin}
+ */
+// eslint-disable-next-line no-unused-vars
+export default function plugin(ctx, inject) {
+  ctx.app.$asciidoc = new AsciidocPlugin(jsonData)
+}

--- a/src/modules/asciidocPresenter/test/__mocks__/fs.ts
+++ b/src/modules/asciidocPresenter/test/__mocks__/fs.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { BaseEncodingOptions, Dirent, PathLike } from 'fs'
+import { basename, dirname, extname } from 'path'
+
+type MockFs = {
+  promises: MockPromises
+}
+type MockPromises = {
+  _setMockFiles: typeof _setMockFiles
+  readdir: typeof readdir
+  readFile: typeof readFile
+  mkdir: typeof mkdir
+  writeFile: typeof writeFile
+}
+
+// fs モジュールのMock化
+const fs: MockFs = jest.genMockFromModule('fs')
+
+// 疑似ファイルを格納
+const mockFiles = new Map<
+  string,
+  { name: string; isFile(): boolean; content: string }[]
+>()
+/**
+ * 疑似ファイルとしてあつかう値をセットする。
+ *
+ * @param newMockFiles keyにファイルパス、valueにファイル内容をとるRecord
+ *
+ * ```
+ * fs.promises._setMockFiles({
+ *   '/path/to/sample/hoge.txt': 'hogehoge'
+ *   '/foo/bar/baz.json': '{"value": "hello"}'
+ * })
+ * ```
+ */
+function _setMockFiles(newMockFiles: Record<string, string>) {
+  mockFiles.clear()
+  Object.keys(newMockFiles).forEach((key) => {
+    const dir = dirname(key)
+    const content = newMockFiles[key]
+
+    if (mockFiles.get(dir) == null) {
+      mockFiles.set(dir, [])
+    }
+
+    mockFiles.get(dir)?.push({
+      name: basename(key),
+      isFile: () => extname(key).length > 1,
+      content,
+    })
+  })
+}
+
+async function readdir(
+  path: PathLike,
+  options?: BaseEncodingOptions
+): Promise<Dirent[]> {
+  const contents = mockFiles.get(path.toString())
+  if (contents == null) {
+    throw Error(`NotFound: ${path}`)
+  }
+
+  return contents.map((x) => {
+    return {
+      isDirectory: () => !x.isFile(),
+      isBlockDevice: () => false,
+      isCharacterDevice: () => false,
+      isSymbolicLink: () => false,
+      isFIFO: () => false,
+      isSocket: () => false,
+      ...x,
+    }
+  })
+}
+
+async function readFile(path: string, options: { encoding: 'utf8' | 'utf-8' }) {
+  const key = dirname(path)
+  const source = mockFiles.get(key)?.find((obj) => obj.name === basename(path))
+    ?.content
+
+  if (source == null) {
+    throw new Error('Not file')
+  }
+  return source
+}
+
+async function writeFile(path: string, data: string): Promise<void> {
+  // mock
+}
+
+async function mkdir(path: PathLike, options: { recursiv: true }) {
+  return 'create'
+}
+
+function isFs(value: unknown): value is MockFs {
+  if (typeof value === 'object') {
+    return value != null && 'promises' in value
+  }
+
+  return false
+}
+
+export const promises: MockPromises = {
+  _setMockFiles,
+  readdir,
+  readFile,
+  mkdir,
+  writeFile,
+}
+
+fs.promises = promises

--- a/src/modules/asciidocPresenter/test/asciidoc.spec.ts
+++ b/src/modules/asciidocPresenter/test/asciidoc.spec.ts
@@ -1,0 +1,109 @@
+import path from 'path'
+import Processer from '@asciidoctor/core'
+import { parse, parseFiles, convertToSummary } from '../utils/asciidoc'
+import { AsciidocParsed } from '../models'
+
+describe('Asciidoc functions', () => {
+  const processer = Processer()
+  // Mock
+  processer.loadFile = (filename, options) => {
+    const map = new Map<string, string>()
+    map
+      .set(
+        'sample01.adoc',
+        `= Sample01 Title
+akiakiS
+v1.9, 2020-08-14
+:tags: test,draft
+:created_at: 2020-08-08
+== Heading
+hogehoge`
+      )
+      .set(
+        'sample02.adoc',
+        `= Sample02
+:tags: foo,bar
+:created_at: 2020-08-15
+== Obon
+Wacchoi!`
+      )
+      .set(
+        'sample03.adoc',
+        `= Sample03
+fuga
+v1.2,2020-08-12
+:tags: third,sample,hoge
+:created_at: 2020-08-06`
+      )
+
+    return processer.load(map.get(path.basename(filename)) ?? 'undefined')
+  }
+
+  test.each([
+    ['./dummy/sample01.adoc', '2020-08-08'],
+    ['./dummy/sample02.adoc', '2020-08-15'],
+  ])('parse %s', (file, createdAt) => {
+    const doc = processer.loadFile(file)
+    const parsed = parse(file, undefined)
+    const expected: AsciidocParsed = {
+      filename: path.basename(file),
+      created_at: doc.getAttribute('created_at'),
+      rendered: doc.convert(),
+      tags: (doc.getAttribute('tags') + '').split(',').map((x) => x.trim()),
+      title: doc.getDocumentTitle(),
+      author: doc.getAttribute('author'),
+      description: doc.getAttribute('description'),
+      updated_at: doc.getRevisionDate(),
+      revision: doc.getRevisionNumber(),
+      revision_remark: doc.getRevisionRemark(),
+    }
+
+    expect(parsed.created_at).toBe(createdAt)
+    expect(parsed).toEqual(expected)
+  })
+
+  describe('parseFiles', () => {
+    test.each([
+      [
+        path.join(__dirname, 'dummy/sample01.adoc'),
+        path.join(__dirname, 'dummy/sample02.adoc'),
+        path.join(__dirname, 'dummy/sample03.adoc'),
+      ],
+    ])('success', (...files) => {
+      const parsed = parseFiles(files, undefined)
+      // latest order
+      expect(parsed[0]).toEqual(parse(files[1], undefined))
+      expect(parsed[1]).toEqual(parse(files[0], undefined))
+      expect(parsed[2]).toEqual(parse(files[2], undefined))
+    })
+
+    test.each([[path.join(__dirname, 'dummy/sample04.adoc')]])(
+      'failed',
+      (...files) => {
+        expect(() => parseFiles(files, undefined)).toThrowError('NoAttribute')
+      }
+    )
+  })
+
+  test('convertToSummary', () => {
+    const expected = { filename: 'path/to/hoge', created_at: '2020-08-14' }
+    const input: AsciidocParsed = {
+      ...expected,
+      rendered: '<div>hello</div>',
+      tags: ['test', 'sample'],
+      title: 'Sample Title',
+      author: 'akiakiS',
+      description: 'sample object',
+      updated_at: '2020-08-15',
+      revision: '1.2',
+      revision_remark: 'hogehoge',
+    }
+
+    const summary = convertToSummary(input)
+    expect(summary).toEqual(expected)
+
+    Object.keys(input)
+      .filter((x) => !(x in expected))
+      .forEach((key) => expect(key in summary).toBeFalsy())
+  })
+})

--- a/src/modules/asciidocPresenter/test/filesystems.spec.ts
+++ b/src/modules/asciidocPresenter/test/filesystems.spec.ts
@@ -1,0 +1,65 @@
+import path from 'path'
+import { fileList, outputSummaryJson } from '../utils/filesystems'
+import { promises as MockFs } from 'fs'
+
+jest.mock('fs')
+
+const mockedFs = MockFs as jest.Mocked<
+  typeof MockFs & typeof import('./__mocks__/fs').promises
+>
+
+describe('FileSystems functions', () => {
+  const mockFiles = {
+    '/foo/sample/file.adoc': '= Sample text',
+    '/foo/sample/hoge.txt': 'hogehoge',
+    '/foo/sample/post.adoc': '= Post Adoc',
+    '/bar/sample/nonList.adoc': '',
+    '/bar/json/hoge.json':
+      '{"dir":"/foo/sample","list":[{"filename":"post.adoc","created_at":"2020-08-08"}]}',
+  }
+
+  beforeEach(() => {
+    mockedFs._setMockFiles(mockFiles)
+  })
+
+  test('fileList', async () => {
+    let list = await fileList(path.join('/foo/sample'))
+    expect(list.length).toBe(2)
+    expect(list).toEqual(['/foo/sample/file.adoc', '/foo/sample/post.adoc'])
+
+    list = await fileList(path.join('/foo/sample'), ['.txt'])
+    expect(list.length).toBe(1)
+    expect(list).toEqual(['/foo/sample/hoge.txt'])
+
+    list = await fileList(path.join('/bar/sample'))
+    expect(list.length).toBe(1)
+    expect(list).toEqual(['/bar/sample/nonList.adoc'])
+
+    const spy = jest.spyOn(console, 'error').mockImplementation((msg) => msg)
+    const empty = await fileList(path.join('/hoge/sample'))
+    expect(empty).toEqual([])
+    expect(spy).toHaveBeenCalled()
+    spy.mockReset()
+  })
+
+  test.each([
+    [
+      '/foo/sample',
+      '/bar/json/hoge.json',
+      [{ filename: 'post.adoc', created_at: '2020-08-08' }],
+      /Write skip/,
+    ],
+    [
+      '/foo/adocs',
+      '/hoge/output.json',
+      [{ filename: 'sample.adoc', created_at: '2020-08-12' }],
+      /Write success/,
+    ],
+  ])('outputSummaryJson', async (dir, json, summaries, pattern) => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => '')
+    await outputSummaryJson(summaries, dir, json)
+    expect(spy.mock.calls[0][0]).toMatch(pattern)
+    spy.mockReset()
+    spy.mockRestore()
+  })
+})

--- a/src/modules/asciidocPresenter/utils/asciidoc.js
+++ b/src/modules/asciidocPresenter/utils/asciidoc.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+import { basename } from 'path'
+import Processor from '@asciidoctor/core'
+
+/**
+ * @type {import('@asciidoctor/core').Asciidoctor} Asciidoctor API
+ */
+const processor = Processor()
+
+/**
+ * AsciiDoc を解析して {@link import('./models').AsciidocParsed} に変換した値について、必須の値が設定されているかどうかを検証。
+ *
+ * @param {import('../models').AsciidocParsed} article 検証するオブジェクト
+ * @throws {TypeError} Argument article is not null about title and created_at
+ */
+function validateArticle(article) {
+  /** @param {string} name */
+  const error = (name) =>
+    new TypeError(
+      `NoAttribute: Please set value of "${name}" in ${article.filename}`
+    )
+
+  if (article.title == null) {
+    throw error('title')
+  }
+
+  if (article.created_at == null) {
+    throw error('created_at')
+  }
+
+  if (article.tags.length <= 0) {
+    throw error('tags')
+  }
+}
+
+/**
+ * AsciiDocファイルを読み込み、各属性などを解析して {@link import('./models').AsciidocParsed} オブジェクトを返す関数。
+ *
+ * @param {string} file AsciiDocファイルのローカルパス。
+ * @param {import('@asciidoctor/core').Asciidoctor.ProcessorOptions | undefined} options クラスメンバのオプションを上書きする Asciidoctor 解析用オプション。
+ *
+ * @returns {import('../models').AsciidocParsed}  {@link import('./models').AsciidocParsed} オブジェクトを返す
+ */
+export function parse(file, options) {
+  const doc = processor.loadFile(file, options)
+
+  /** @type {import('../models').AsciidocParsed} */
+  const parsing = {
+    filename: basename(file),
+    rendered: doc.convert(),
+    title: doc.getDocumentTitle(),
+    created_at: doc.getAttribute('created_at'),
+    tags: (doc.getAttribute('tags') + '')
+      .split(',')
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0),
+
+    updated_at: doc.getRevisionDate(),
+    author: doc.getAttribute('author'),
+    description: doc.getAttribute('description'),
+    revision: doc.getRevisionNumber(),
+    revision_remark: doc.getRevisionRemark(),
+  }
+
+  validateArticle(parsing)
+  return parsing
+}
+
+/**
+ * 各AsciiDocファイルを読み込み、各属性などを解析して {@link import('./models').AsciidocParsed} オブジェクトの配列を返す関数。
+ *
+ * 返す配列は `created_at` 属性値から、日付が新しい順にして返す。
+ *
+ * @param {string[]} files AsciiDocファイルのパスのリスト。
+ * @param {import('@asciidoctor/core').Asciidoctor.ProcessorOptions | undefined} options クラスメンバのオプションを上書きする Asciidoctor 解析用オプション。
+ *
+ * @returns {import('../models').AsciidocParsed[]}  {@link import('./models').AsciidocParsed} オブジェクトを返す
+ */
+export function parseFiles(files, options) {
+  return files
+    .map((file) => parse(file, options))
+    .sort((a, b) => {
+      const aTime = new Date(a.created_at).getTime(),
+        bTime = new Date(b.created_at).getTime()
+
+      if (aTime === bTime) {
+        return a.title.toString().localeCompare(b.title.toString())
+      }
+
+      return aTime > bTime ? -1 : 1
+    })
+}
+
+/**
+ * {@link import('../models').AsciidocParsed} から {@link import('../models').AsciidocSummary} へ変換する（不要なプロパティを削除する）。
+ *
+ * @param {import('../models').AsciidocParsed} asciidocParsed
+ * @returns {import('../models').AsciidocSummary}
+ */
+export function convertToSummary(asciidocParsed) {
+  // eslint-disable-next-line no-unused-vars
+  const { filename, created_at, ...remain } = asciidocParsed
+  return {
+    filename,
+    created_at,
+  }
+}

--- a/src/modules/asciidocPresenter/utils/filesystems.js
+++ b/src/modules/asciidocPresenter/utils/filesystems.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+import { promises as fs } from 'fs'
+import { extname, join } from 'path'
+import equal from 'fast-deep-equal'
+
+/**
+ * fs Promises API の {@link fs.mkdir} 関数のラッパー。
+ */
+export const mkdir = fs.mkdir
+
+/**
+ * 指定されたディレクトリ直下のファイル一覧を取得し、そのパスのリストを返す関数。
+ *
+ * @param {string} dirpath ファイル一覧を取得するディレクトリのパス
+ * @param {string[]} extnames 検索対象とするファイル拡張子のリスト
+ * @returns {Promise<string[]>} ファイルパスの配列
+ */
+export async function fileList(dirpath, extnames = ['.adoc', '.asciidoc']) {
+  /** @type {import('fs').Dirent[]} */
+  const dirent = await fs
+    .readdir(dirpath, { withFileTypes: true })
+    .catch((err) => {
+      console.error(err)
+      return []
+    })
+
+  return dirent
+    .filter((x) => x.isFile())
+    .filter((x) => extnames.some((ext) => extname(x.name) === ext))
+    .map((x) => {
+      return join(dirpath, x.name)
+    })
+}
+
+/**
+ * 出力先ファイルが存在しかつJSONの値が同じであればtrueを返す。
+ * それ以外はfalseを返す。
+ *
+ * @param {string} target 出力先ファイルパス
+ * @param {string} value 同一性を判定するJSON
+ * @param {BufferEncoding=} encoding 既存ファイルのエンコーディング。デフォルトはutf8
+ */
+async function equalExistJson(target, value, encoding = 'utf8') {
+  const origin = await fs
+    .readFile(target, { encoding: encoding })
+    .catch(() => '{}')
+
+  return equal(JSON.parse(origin), JSON.parse(value))
+}
+
+/**
+ * AsciiDoc記事の一覧用JSONファイルを作成。
+ *
+ * {@link import('./models').AsciidocSummary} から一覧として不要な要素を排除したJSONオブジェクトを生成して出力する。
+ *
+ * @param {import('../models').AsciidocSummary[]} summary 解析済みのオブジェクト
+ * @param {string} sourceDir AsciiDocファイルのあるディレクトリパス
+ * @param {string} jsonFile 出力先JSONファイルパス
+ */
+export async function outputSummaryJson(summary, sourceDir, jsonFile) {
+  /** @type {import('../models').AsciidocSummaryJson} */
+  const jsonData = {
+    dir: sourceDir,
+    list: summary,
+  }
+
+  // 既存ファイルの内容と同じ値ならば書き込みしない
+  if (await equalExistJson(jsonFile, JSON.stringify(jsonData))) {
+    console.log('🌟 Write skip, bcause same value.')
+    return
+  }
+
+  // 出力先JSONファイルに書き込み（上書き）
+  fs.writeFile(jsonFile, JSON.stringify(jsonData))
+    .then(() => console.log(`🌟 Write success => ${jsonFile}`))
+    .catch((err) => console.error(`⚠️ Write failed. ${err}`))
+}

--- a/src/modules/asciidocPresenter/utils/index.js
+++ b/src/modules/asciidocPresenter/utils/index.js
@@ -1,0 +1,2 @@
+export * from './asciidoc'
+export * from './filesystems'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@asciidoctor/core@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@asciidoctor/core/-/core-2.2.0.tgz#cae722e32666bf3c38365afe7d05f2f433b165fd"
+  integrity sha512-WN/mFuU4SeWaDqpGvRwAf+Tq2T8NQkVVpZ3Ne1/ZRxDKElzFkqq8bGbmxSMWmMVzC+H9ZO1YxxbOjhWEiNvpOA==
+  dependencies:
+    asciidoctor-opal-runtime "0.3.0"
+    unxhr "1.0.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -2848,6 +2856,14 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+asciidoctor-opal-runtime@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.0.tgz#df327a870ddd3cd5eb0e162d64ed4dcdd3fe3fee"
+  integrity sha512-YapVwl2qbbs6sIe1dvAlMpBzQksFVTSa2HOduOKFNhZlE9bNmn+moDgGVvjWPbzMPo/g8gItyTHfWB2u7bQxag==
+  dependencies:
+    glob "7.1.3"
+    unxhr "1.0.1"
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -4959,6 +4975,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -5293,6 +5314,18 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
@@ -8609,7 +8642,7 @@ postcss@^6.0.9:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
-    
+
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.18, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.27, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
@@ -10428,6 +10461,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unxhr@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unxhr/-/unxhr-1.0.1.tgz#92200322d66c728993de771f9e01eeb21f41bc7b"
+  integrity sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==
 
 upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
あるディレクトリ直下にあるAsciiDocファイル一覧を取得してJSONファイルとして出力するモジュール。
またAsciiDocファイルを解析したデータを提供するプラグインも一緒に実装。

- chore: add fast-deep-equal package
- chore: add an @asciidoctor/core package
- style: update eslint rules
- feat: create module & plugin for reading asciidoc
- test: create tests for module

close #114