### PR TITLE
fix: 型定義を宣言ファイルへ修正

### DIFF
--- a/src/modules/asciidocPresenter/index.d.ts
+++ b/src/modules/asciidocPresenter/index.d.ts
@@ -55,3 +55,13 @@ export interface AsciidocParsed extends AsciidocSummary {
   revision?: string // '1.1 (revision number)'
   revision_remark?: string // 'update comment (revision remark)'
 }
+
+// context.app にプラグインをInject
+declare module '@nuxt/types' {
+  interface NuxtAppOptions {
+    /**
+     * AsciiDocファイルを解析したデータを提供する
+     */
+    $asciidoc: import('./plugin').AsciidocPlugin
+  }
+}

--- a/src/modules/asciidocPresenter/index.js
+++ b/src/modules/asciidocPresenter/index.js
@@ -5,7 +5,7 @@ import * as utils from './utils'
 /**
  * _AsciiDoc_ ファイルをNuxtビルド前にJSONファイルとして出力するモジュール。
  *
- * @type {import('@nuxt/types').Module<import('./models').ModuleOptions>}
+ * @type {import('@nuxt/types').Module<import('.').ModuleOptions>}
  */
 export default function AsciidocPresenter(moduleOptions) {
   const options = {

--- a/src/modules/asciidocPresenter/plugin.js
+++ b/src/modules/asciidocPresenter/plugin.js
@@ -10,9 +10,10 @@ import jsonData from '<%= options.jsonFile %>'
 export class AsciidocPlugin {
   /**
    *
-   * @param {import('./models').AsciidocSummaryJson} summaryJson ファイル一覧データを含むオブジェクト
+   * @param {import('.').AsciidocSummaryJson} summaryJson ファイル一覧データを含むオブジェクト
    */
   constructor(summaryJson) {
+    /** ファイル一覧を含むJSONオブジェクト */
     this.summaryJson = summaryJson
   }
 
@@ -43,7 +44,7 @@ export class AsciidocPlugin {
    *
    * @param {string} filename AsciiDocソースファイル名
    * @throws {Error} Not found filename in summary path lists
-   * @returns {Promise<import('./models').AsciidocParsed>} AsciiDocの解析データを返す。
+   * @returns {Promise<import('.').AsciidocParsed>} AsciiDocの解析データを返す。
    */
   async loadFile(filename) {
     const filepath = this.__findSummaryFromList(filename)

--- a/src/modules/asciidocPresenter/test/asciidoc.spec.ts
+++ b/src/modules/asciidocPresenter/test/asciidoc.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import Processer from '@asciidoctor/core'
 import { parse, parseFiles, convertToSummary } from '../utils/asciidoc'
-import { AsciidocParsed } from '../models'
+import { AsciidocParsed } from '..'
 
 describe('Asciidoc functions', () => {
   const processer = Processer()

--- a/src/modules/asciidocPresenter/utils/asciidoc.js
+++ b/src/modules/asciidocPresenter/utils/asciidoc.js
@@ -11,7 +11,7 @@ const processor = Processor()
 /**
  * AsciiDoc を解析して {@link import('./models').AsciidocParsed} に変換した値について、必須の値が設定されているかどうかを検証。
  *
- * @param {import('../models').AsciidocParsed} article 検証するオブジェクト
+ * @param {import('..').AsciidocParsed} article 検証するオブジェクト
  * @throws {TypeError} Argument article is not null about title and created_at
  */
 function validateArticle(article) {
@@ -40,12 +40,12 @@ function validateArticle(article) {
  * @param {string} file AsciiDocファイルのローカルパス。
  * @param {import('@asciidoctor/core').Asciidoctor.ProcessorOptions | undefined} options クラスメンバのオプションを上書きする Asciidoctor 解析用オプション。
  *
- * @returns {import('../models').AsciidocParsed}  {@link import('./models').AsciidocParsed} オブジェクトを返す
+ * @returns {import('..').AsciidocParsed}  {@link import('./models').AsciidocParsed} オブジェクトを返す
  */
 export function parse(file, options) {
   const doc = processor.loadFile(file, options)
 
-  /** @type {import('../models').AsciidocParsed} */
+  /** @type {import('..').AsciidocParsed} */
   const parsing = {
     filename: basename(file),
     rendered: doc.convert(),
@@ -75,7 +75,7 @@ export function parse(file, options) {
  * @param {string[]} files AsciiDocファイルのパスのリスト。
  * @param {import('@asciidoctor/core').Asciidoctor.ProcessorOptions | undefined} options クラスメンバのオプションを上書きする Asciidoctor 解析用オプション。
  *
- * @returns {import('../models').AsciidocParsed[]}  {@link import('./models').AsciidocParsed} オブジェクトを返す
+ * @returns {import('..').AsciidocParsed[]}  {@link import('./models').AsciidocParsed} オブジェクトを返す
  */
 export function parseFiles(files, options) {
   return files
@@ -95,8 +95,8 @@ export function parseFiles(files, options) {
 /**
  * {@link import('../models').AsciidocParsed} から {@link import('../models').AsciidocSummary} へ変換する（不要なプロパティを削除する）。
  *
- * @param {import('../models').AsciidocParsed} asciidocParsed
- * @returns {import('../models').AsciidocSummary}
+ * @param {import('..').AsciidocParsed} asciidocParsed
+ * @returns {import('..').AsciidocSummary}
  */
 export function convertToSummary(asciidocParsed) {
   // eslint-disable-next-line no-unused-vars

--- a/src/modules/asciidocPresenter/utils/filesystems.js
+++ b/src/modules/asciidocPresenter/utils/filesystems.js
@@ -54,12 +54,12 @@ async function equalExistJson(target, value, encoding = 'utf8') {
  *
  * {@link import('./models').AsciidocSummary} から一覧として不要な要素を排除したJSONオブジェクトを生成して出力する。
  *
- * @param {import('../models').AsciidocSummary[]} summary 解析済みのオブジェクト
+ * @param {import('..').AsciidocSummary[]} summary 解析済みのオブジェクト
  * @param {string} sourceDir AsciiDocファイルのあるディレクトリパス
  * @param {string} jsonFile 出力先JSONファイルパス
  */
 export async function outputSummaryJson(summary, sourceDir, jsonFile) {
-  /** @type {import('../models').AsciidocSummaryJson} */
+  /** @type {import('..').AsciidocSummaryJson} */
   const jsonData = {
     dir: sourceDir,
     list: summary,


### PR DESCRIPTION
自作Nuxtモジュールの型やプラグインの型を `.vue` ファイルで自動的に扱えるように、
型定義を宣言ファイルに記述するよう修正。

- fix: rename from model.ts
- style: create a type definition