### PR TITLE
refactor: 記事本文用のCSSを別ファイルに分離

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   },
   "[typescript]": {
     //"editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "asciidoc.preview.style": "src/static/stylesheets/asciidoc-style.css"
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mdlist": "node --experimental-modules fileListToJson.mjs",
     "sass-build": "sass -I ./node_modules src/assets/css/scss/",
     "start": "nuxt-ts start",
+    "tailwind-build": "tailwindcss build src/assets/css/post/_post-body.css -c src/tailwind.config.js -o src/static/stylesheets/asciidoc-style.css",
     "test": "jest",
     "test-ci": "jest --coverage false"
   },

--- a/src/assets/css/post/_post-body.css
+++ b/src/assets/css/post/_post-body.css
@@ -1,0 +1,116 @@
+/* Heading Level */
+h1 {
+  @apply text-4xl font-light;
+}
+h2 {
+  @apply text-3xl font-normal mt-8;
+}
+h3 {
+  @apply text-2xl font-semibold mt-6;
+}
+h4 {
+  @apply text-xl font-semibold mt-4;
+}
+h5 {
+  @apply text-lg font-semibold mt-4;
+}
+h6 {
+  @apply text-base font-semibold mt-4;
+}
+
+/* Paragrap*/
+p {
+  @apply mt-4;
+}
+
+/* List */
+ul,
+ol {
+  @apply pl-6 mt-4;
+}
+ul {
+  @apply list-disc;
+}
+ol {
+  @apply list-decimal;
+}
+li {
+  @apply mt-2;
+}
+> ul,
+> ol {
+  @apply pl-4 mt-0;
+}
+
+/* Table */
+table {
+  @apply table-auto border-collapse mt-4;
+}
+tr {
+  @apply border-b border-black border-opacity-50;
+}
+tr:nth-of-type(even) {
+  @apply bg-primary-light bg-opacity-15;
+}
+th {
+  @apply px-4 py-3;
+}
+td {
+  @apply px-4 py-2;
+}
+
+/* Blockquote */
+blockquote {
+  @apply border-l-4;
+  @apply border-primary border-opacity-54;
+  @apply text-black text-opacity-75 italic;
+  @apply pl-4;
+}
+
+hr {
+  @apply border-grey-500 mt-6;
+}
+
+/* Link */
+a {
+  @apply text-indigo-500;
+}
+a:hover {
+  @apply underline;
+}
+a:visited {
+  @apply text-purple-800;
+}
+
+/* Codes */
+pre,
+code {
+  font-family: 'Roboto Mono', monospace;
+}
+
+/* Inline Code */
+:not(pre) code {
+  @apply rounded-sm bg-primary bg-opacity-38;
+  @apply px-1;
+
+  color: rgb(var(--md-dark-text-primary-rgb));
+}
+
+/* Code Block */
+pre {
+  @apply relative rounded mt-4;
+}
+pre:not([data-lang]) {
+  @apply py-4 pr-6;
+}
+pre[data-lang] {
+  @apply pb-4;
+}
+pre[data-lang]::before {
+  @apply text-primary-light text-opacity-54;
+  @apply border-b border-dashed border-opacity-50;
+  @apply -mt-2 mb-4 -ml-3;
+
+  content: attr(data-lang);
+  display: block;
+}

--- a/src/components/organisms/ArticleBody.spec.ts
+++ b/src/components/organisms/ArticleBody.spec.ts
@@ -41,7 +41,7 @@ describe('ArticleBody', () => {
     expect(wrapper2.contains('h1')).toBeFalsy()
     expect(wrapper2.contains('h2')).toBeTruthy()
     expect(wrapper2.contains('code')).toBeTruthy()
-    expect(wrapper2.contains('.markdown-body')).toBeTruthy()
+    expect(wrapper2.contains('.post-body')).toBeTruthy()
     expect(wrapper2.find('h2').text()).toBe('Remain this header')
   })
 

--- a/src/components/organisms/ArticleBody.vue
+++ b/src/components/organisms/ArticleBody.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="markdown-body line-numbers" v-html="body"></div>
+    <div class="post-body line-numbers" v-html="body"></div>
   </div>
 </template>
 
@@ -8,7 +8,18 @@
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
 import '@/helpers/string.extension'
 
-@Component
+@Component({
+  head() {
+    return {
+      link: [
+        {
+          rel: 'stylesheet',
+          href: '/stylesheets/asciidoc-style.css',
+        },
+      ],
+    }
+  },
+})
 export default class ArticleBody extends Vue {
   /**
    * HTMLレンダリングされた _Markdown_ ソース。
@@ -24,127 +35,4 @@ export default class ArticleBody extends Vue {
 }
 </script>
 
-<style lang="scss">
-.markdown-body {
-  // Heading Level
-  h1 {
-    @apply text-4xl font-light;
-  }
-  h2 {
-    @apply text-3xl font-normal mt-8;
-  }
-  h3 {
-    @apply text-2xl font-semibold mt-6;
-  }
-  h4 {
-    @apply text-xl font-semibold mt-4;
-  }
-  h5 {
-    @apply text-lg font-semibold mt-4;
-  }
-  h6 {
-    @apply text-base font-semibold mt-4;
-  }
-
-  // Paragraph
-  p {
-    @apply mt-4;
-  }
-
-  // List
-  ul,
-  ol {
-    @apply pl-6 mt-4;
-  }
-  li {
-    @apply mt-2;
-
-    > ul,
-    > ol {
-      @apply pl-4 mt-0;
-    }
-  }
-  ul {
-    @apply list-disc;
-  }
-  ol {
-    @apply list-decimal;
-  }
-
-  // Table
-  table {
-    @apply table-auto border-collapse mt-4;
-  }
-  tr {
-    @apply border-b border-black border-opacity-50;
-
-    &:nth-of-type(even) {
-      @apply bg-primary-light bg-opacity-15;
-    }
-  }
-  th {
-    @apply px-4 py-3;
-  }
-  td {
-    @apply px-4 py-2;
-  }
-
-  // Blockquote
-  blockquote {
-    @apply border-l-4 border-primary border-opacity-54;
-    @apply text-black text-opacity-75 italic;
-    @apply pl-4;
-  }
-
-  hr {
-    @apply border-grey-500 mt-6;
-  }
-
-  a {
-    @apply text-indigo-500;
-
-    &:hover {
-      @apply underline;
-    }
-
-    &:visited {
-      @apply text-purple-800;
-    }
-  }
-
-  // Codes
-  pre,
-  code {
-    font-family: 'Roboto Mono', monospace;
-  }
-
-  // Inline Code
-  :not(pre) code {
-    @apply rounded-sm bg-primary bg-opacity-38;
-    @apply px-1;
-
-    color: rgb(var(--md-dark-text-primary-rgb));
-  }
-
-  // Code Block
-  pre {
-    @apply relative rounded mt-4;
-
-    &:not([data-lang]) {
-      @apply py-4 pr-6;
-    }
-  }
-  pre[data-lang] {
-    @apply pb-4;
-
-    &::before {
-      @apply text-primary-light text-opacity-54;
-      @apply border-b border-dashed border-opacity-50;
-      @apply -mt-2 mb-4 -ml-3;
-
-      content: attr(data-lang);
-      display: block;
-    }
-  }
-}
-</style>
+<style></style>

--- a/src/static/stylesheets/asciidoc-style.css
+++ b/src/static/stylesheets/asciidoc-style.css
@@ -1,0 +1,199 @@
+/* Heading Level */
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 300;
+}
+
+h2 {
+  font-size: 1.875rem;
+  font-weight: 400;
+  margin-top: 2rem;
+}
+
+h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+}
+
+h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+h5 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+h6 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+}
+
+/* Paragrap*/
+
+p {
+  margin-top: 1rem;
+}
+
+/* List */
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-top: 1rem;
+}
+
+ul {
+  list-style-type: disc;
+}
+
+ol {
+  list-style-type: decimal;
+}
+
+li {
+  margin-top: 0.5rem;
+}
+
+> ul,
+> ol {
+  padding-left: 1rem;
+  margin-top: 0;
+}
+
+/* Table */
+
+table {
+  table-layout: auto;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+tr {
+  border-bottom-width: 1px;
+  --border-opacity: 1;
+  border-color: #000000;
+  border-color: rgba(0, 0, 0, var(--border-opacity));
+  --border-opacity: 0.5;
+}
+
+tr:nth-of-type(even) {
+  --bg-opacity: 1;
+  background-color: #ffd54f;
+  background-color: rgba(255, 213, 79, var(--bg-opacity));
+  --bg-opacity: 0.15;
+}
+
+th {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+td {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+/* Blockquote */
+
+blockquote {
+  border-left-width: 4px;
+  --border-opacity: 1;
+  border-color: #ffc107;
+  border-color: rgba(255, 193, 7, var(--border-opacity));
+  --border-opacity: 0.54;
+  --text-opacity: 1;
+  color: #000000;
+  color: rgba(0, 0, 0, var(--text-opacity));
+  --text-opacity: 0.75;
+  font-style: italic;
+  padding-left: 1rem;
+}
+
+hr {
+  --border-opacity: 1;
+  border-color: #9e9e9e;
+  border-color: rgba(158, 158, 158, var(--border-opacity));
+  margin-top: 1.5rem;
+}
+
+/* Link */
+
+a {
+  --text-opacity: 1;
+  color: #3f51b5;
+  color: rgba(63, 81, 181, var(--text-opacity));
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+a:visited {
+  --text-opacity: 1;
+  color: #6a1b9a;
+  color: rgba(106, 27, 154, var(--text-opacity));
+}
+
+/* Codes */
+
+pre,
+code {
+  font-family: 'Roboto Mono', monospace;
+}
+
+/* Inline Code */
+
+:not(pre) code {
+  border-radius: 0.125rem;
+  --bg-opacity: 1;
+  background-color: #ffc107;
+  background-color: rgba(255, 193, 7, var(--bg-opacity));
+  --bg-opacity: 0.38;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  color: rgb(var(--md-dark-text-primary-rgb));
+}
+
+/* Code Block */
+
+pre {
+  position: relative;
+  border-radius: 0.25rem;
+  margin-top: 1rem;
+}
+
+pre:not([data-lang]) {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-right: 1.5rem;
+}
+
+pre[data-lang] {
+  padding-bottom: 1rem;
+}
+
+pre[data-lang]::before {
+  --text-opacity: 1;
+  color: #ffd54f;
+  color: rgba(255, 213, 79, var(--text-opacity));
+  --text-opacity: 0.54;
+  border-bottom-width: 1px;
+  border-style: dashed;
+  --border-opacity: 0.5;
+  margin-top: -0.5rem;
+  margin-bottom: 1rem;
+  margin-left: -0.75rem;
+  content: attr(data-lang);
+  display: block;
+}

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -7,8 +7,10 @@
 
 /* eslint-env node, es6 */
 
-import { opacity } from 'tailwindcss/defaultTheme'
-import palette from 'material-colors'
+/** @type {{opacity: Record<string, string>}} */
+const { opacity } = require('tailwindcss/defaultTheme')
+/** @type {import('material-colors/dist/colors.json')} */
+const palette = require('material-colors/dist/colors.json')
 
 function customColorProperty(type, colorName) {
   const propertyMap = new Map([


### PR DESCRIPTION
_VS Code_ でも同じスタイルシートを利用して記事プレビューできるようにするため、
単一CSSファイルとして分離。

- refactor: change to 'require' from 'import'
- refactor: separate to stylesheet files
- chore: set a stylesheet for vscode preview

fix #111