### PR TITLE
fix: モジュール内のServerMiddlewareの機能をwebpack pluginで置き換え

### DIFF
--- a/src/modules/asciidocPresenter/index.d.ts
+++ b/src/modules/asciidocPresenter/index.d.ts
@@ -2,13 +2,18 @@
  * モジュールのオプション。
  *
  * @param {string} source 直下に AsciiDoc ファイルがあるディレクトリのパス
- * @param {string=} apiPath 解析したAsciiDocファイルをJSONでAPI提供するパスのルート。デフォルト `/api/asciidoc`
+ * @param {ModuleApi=} apiPath 解析したAsciiDocファイルをJSONでAPI提供するパスのルート。デフォルト `/api/asciidoc`
  * @param {string=} number AsciiDocファイル一覧を出力するJSONファイル名。デフォルト `20`
  */
 export interface ModuleOptions {
   source?: string
-  apiPath?: string
+  apiPath?: Partial<ModuleApi>
   count?: number
+}
+
+export type ModuleApi = {
+  overview: string
+  contents: string
 }
 
 /**

--- a/src/modules/asciidocPresenter/plugin.server.js
+++ b/src/modules/asciidocPresenter/plugin.server.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { withoutExtension, PluginBase } from './pluginBase'
+import { adocParsedList, withoutExtension, PluginBase } from './pluginBase'
 
 export class PluginServer extends PluginBase {
   /**
@@ -61,12 +61,7 @@ export class PluginServer extends PluginBase {
  */
 // eslint-disable-next-line no-unused-vars
 export default function plugin(ctx, inject) {
-  // オブジェクトをJSON文字列化、エスケープ文字をそのまま残す
-  const contents = String.raw`<%= JSON.stringify(options.contents) %>`
-  /** @type {import('.').AsciidocParsed[]} */
-  const items = JSON.parse(contents)
-
   const count = parseInt('<%= options.count %>', 10)
 
-  ctx.app.$asciidoc = new PluginServer(count, items)
+  ctx.app.$asciidoc = new PluginServer(count, adocParsedList)
 }

--- a/src/modules/asciidocPresenter/pluginBase.js
+++ b/src/modules/asciidocPresenter/pluginBase.js
@@ -80,3 +80,9 @@ export class PluginBase {
 export function withoutExtension(filename) {
   return basename(filename, extname(filename))
 }
+
+/** @type {import('.').AsciidocParsed[]} */
+export const adocParsedList = JSON.parse(
+  // オブジェクトをJSON文字列化、エスケープ文字をそのまま残す
+  String.raw`<%= JSON.stringify(options.contents) %>`
+)

--- a/src/modules/asciidocPresenter/utils/index.js
+++ b/src/modules/asciidocPresenter/utils/index.js
@@ -1,2 +1,3 @@
 export * from './asciidoc'
 export * from './filesystems'
+export * from './webpack'

--- a/src/modules/asciidocPresenter/utils/webpack.js
+++ b/src/modules/asciidocPresenter/utils/webpack.js
@@ -1,0 +1,90 @@
+// @ts-check
+import { join } from 'path'
+import { withoutExtension } from './util'
+
+/**
+ * Webpackのプラグインを返す。
+ * @param {Readonly<import('..').AsciidocParsed[]>} contents
+ * @param {number} count
+ * @param {Readonly<import('..').ModuleApi>} api
+ * @return {import('webpack').Plugin} Webpack plugin
+ */
+export function createPlugin(contents, count, api) {
+  /** @type {import('..').AsciidocAttribute[]} */
+  const attributes = contents.map((x) => {
+    // eslint-disable-next-line no-unused-vars
+    const { rendered, ...remain } = x
+    return remain
+  })
+
+  /**
+   * @type {import('..').AsciidocOverview[]}
+   */
+  const overviews = split(attributes, count).map((xs, idx, org) => {
+    return {
+      paging: {
+        current: idx + 1,
+        total: org.length,
+      },
+      overviews: xs,
+    }
+  })
+
+  /** @type {import('..').AsciidocOverview} */
+  const allOverview = {
+    paging: { current: 0, total: overviews.length },
+    overviews: attributes,
+  }
+
+  return {
+    apply(compiler) {
+      compiler.hooks.emit.tap('Asciidoc', (compilation) => {
+        /**
+         * オブジェクトデータを新しいファイルとしてアセットに挿入。
+         *
+         * @param {string} name アセットに登録するファイル名
+         * @param {Record<string, any>} obj オブジェクトデータ
+         */
+        const addAssets = (name, obj) => {
+          const data = JSON.stringify(obj)
+          compilation.assets[name] = {
+            source: () => data,
+            size: () => data.length,
+          }
+        }
+
+        // Asciidoc一覧
+        addAssets(join(api.overview, 'all.json'), allOverview)
+        overviews.forEach((overview) => {
+          addAssets(
+            join(api.overview, `${overview.paging.current}.json`),
+            overview
+          )
+        })
+
+        // 各Asciidoc
+        contents.forEach((content) => {
+          addAssets(
+            join(api.contents, `${withoutExtension(content.filename)}.json`),
+            content
+          )
+        })
+      })
+    },
+  }
+}
+
+/**
+ * @template T
+ * @param {Array<T>} array
+ * @param {number} n
+ */
+function split(array, n) {
+  /** @type {Array<Array<T>>} */
+  let result = []
+  for (let idx = 0; idx < array.length; idx = idx + n) {
+    result.push(array.slice(idx, idx + n))
+  }
+
+  return result
+}


### PR DESCRIPTION
ServerMiddlewareの実装をWebpackプラグインで置き換え。

- feat: add webpack plugin for asciidoc
- fix: use webpack plugin
- fix: fix to provide contents of asciidoc

fix #129 