### PR TITLE
fix: Asciidoc内でバッククォート表示した場合のエラー修正

### DIFF
--- a/src/modules/asciidocPresenter/index.d.ts
+++ b/src/modules/asciidocPresenter/index.d.ts
@@ -4,11 +4,13 @@
  * @param {string} source 直下に AsciiDoc ファイルがあるディレクトリのパス
  * @param {ModuleApi=} apiPath 解析したAsciiDocファイルをJSONでAPI提供するパスのルート。デフォルト `/api/asciidoc`
  * @param {string=} number AsciiDocファイル一覧を出力するJSONファイル名。デフォルト `20`
+ * @param {import('@asciidoctor/core').Asciidoctor.ProcessorOptions} processorOptions Asciidoctorのコンバートオプション(https://asciidoctor-docs.netlify.app/asciidoctor.js/processor/convert-options/)
  */
 export interface ModuleOptions {
   source?: string
   apiPath?: Partial<ModuleApi>
   count?: number
+  processorOptions?: import('@asciidoctor/core').Asciidoctor.ProcessorOptions
 }
 
 export type ModuleApi = {

--- a/src/modules/asciidocPresenter/pluginBase.js
+++ b/src/modules/asciidocPresenter/pluginBase.js
@@ -81,8 +81,8 @@ export function withoutExtension(filename) {
   return basename(filename, extname(filename))
 }
 
-/** @type {import('.').AsciidocParsed[]} */
-export const adocParsedList = JSON.parse(
+/** @type {import('.').AsciidocSummaryJson} */
+export const asciidocFiles = JSON.parse(
   // オブジェクトをJSON文字列化、エスケープ文字をそのまま残す
-  String.raw`<%= JSON.stringify(options.contents) %>`
+  String.raw`<%= JSON.stringify(options.summary) %>`
 )


### PR DESCRIPTION
Asciidocファイルの文中にてバッククォート `` ` `` が含まれる場合、プラグインへの変数わたしで `lodash template` を利用しているとエラーが発生していたのを修正。

プラグインにはファイルパスを渡し、プラグイン内にてファイルを読み込み・解析するようにした。

fix #131