### PR TITLE
fix: モジュールのpublicPath指定を修正

### DIFF
--- a/src/modules/asciidocPresenter/index.js
+++ b/src/modules/asciidocPresenter/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { resolve } from 'path'
+import { resolve, join } from 'path'
 import * as utils from './utils'
 
 /**
@@ -25,7 +25,9 @@ export default async function AsciidocPresenter(moduleOptions) {
    * Nuxtのソースディレクトリパス（デフォルトはルートパス）
    */
   const srcDir = this.options.srcDir
-  if (srcDir == null) {
+  // @ts-ignore
+  const publicPath = this.options.build.publicPath
+  if (srcDir == null || publicPath == null) {
     throw new Error('Cannot read nuxt configuration')
   }
 
@@ -77,6 +79,8 @@ export default async function AsciidocPresenter(moduleOptions) {
       src: resolve(__dirname, 'plugin.client.js'),
       options: {
         itemsApi: options.apiPath,
+        // @ts-ignore
+        publicPath: join(this.options.router.base, publicPath),
         count: options.count,
       },
     })

--- a/src/modules/asciidocPresenter/plugin.client.js
+++ b/src/modules/asciidocPresenter/plugin.client.js
@@ -62,7 +62,8 @@ export default function plugin(ctx, inject) {
     String.raw`<%= JSON.stringify(options.itemsApi) %>`
   )
 
+  const publicPath = '<%= options.publicPath %>'
   const count = parseInt('<%= options.count %>', 10)
 
-  ctx.app.$asciidoc = new PluginClient(count, itemsApi)
+  ctx.app.$asciidoc = new PluginClient(count, itemsApi, publicPath)
 }


### PR DESCRIPTION
GitHub Pagesへデプロイ時に `fetch` 先URLパスがNuxtのbaseを考慮できていなかった部分を修正。

close #136