### PR TITLE
fix: workflow file

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'src/**'
+      - '.github/**'
       - '.babelrc'
       - 'nuxt.config.js'
       - 'package.json'


### PR DESCRIPTION
workflow ファイル自身が対象パスに含まれないとトリガー開始しなかったので修正。