### PR TITLE
chore: デプロイ・ワークフローを手動実行できるように変更

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,13 +2,15 @@ name: github pages
 
 on:
   push:
+    branches:
+      - master
+      paths-ignore:
+        - '.vscode/**'
+        - 'docs/**'
+        - 'test/**'
   workflow_dispatch:
     branches:
       - master
-    paths-ignore:
-      - '.vscode/**'
-      - 'docs/**'
-      - 'test/**'
 
 jobs:
   build-deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,9 +2,9 @@ name: github pages
 
 on:
   push:
+  workflow_dispatch:
     branches:
       - master
-      - orphan/article
     paths-ignore:
       - '.vscode/**'
       - 'docs/**'

--- a/.github/workflows/testing_pull_request.yml
+++ b/.github/workflows/testing_pull_request.yml
@@ -32,11 +32,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: install
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
         run: yarn install
 
       - name: install offline
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        if: ${{ steps.yarn-cache.outputs.cache-hit == 'true' }}
         run: yarn install --offline
 
       - name: test


### PR DESCRIPTION
デプロイ用のワークフローをREST APIから実行できるように変更。
また、テスト用ワークフローについて条件式を `act` に合わせた修正。