### PR TITLE
fix: 画像ディレクトリのパス指定を相対パスに修正

### DIFF
--- a/source/commons/attrs.adoc
+++ b/source/commons/attrs.adoc
@@ -3,7 +3,7 @@
 // tag::images[]
 :imagesdir: ../../../static/images
 ifdef::env-nuxt[]
-:imagesdir: /images
+:imagesdir: images
 endif::[]
 // end::images[]
 


### PR DESCRIPTION
- fix: fix the image link to relative path

fix #168