### PR TITLE
feat: add settings of kroki in built time

### DIFF
--- a/source/commons/attrs.adoc
+++ b/source/commons/attrs.adoc
@@ -1,5 +1,12 @@
 :hardbreaks:
 
+// tag::kroki[]
+//:kroki-server-url: https://kroki.io
+ifdef::env-nuxt[]
+:kroki-default-options: inline
+endif::[]
+// end::kroki[]
+
 // tag::images[]
 :imagesdir: ../../../static/images
 ifdef::env-nuxt[]


### PR DESCRIPTION
[`asciidoctor-kroki`](https://github.com/Mogztter/asciidoctor-kroki) 用のオプションを設定。

_Nuxt_ ビルド時（`env-nuxt` 変数が設定されたときのみ）にダイアグラムをインライン `svg` にする。
これによって `kroki` サーバーへのアクセスをビルド時のみに限定する。

link #179 