### PR TITLE
fix: 検索ページのページネーションを修正

### DIFF
--- a/src/components/templates/SearchPage.spec.ts
+++ b/src/components/templates/SearchPage.spec.ts
@@ -118,15 +118,20 @@ describe('SearchPage', () => {
     })
   })
 
-  test('pageIndex', () => {
+  describe('pageIndex', () => {
     const views = new Array(41).fill({ tags: 'hoge' })
 
-    const w = factory(views, '/?page=1')
-    assertSeachPage(w.vm)
+    test.each([
+      ['/?page=1', 1, 3],
+      ['/?tags=foo&page=3', 1, 1],
+    ])('path: %s', (path, num, total) => {
+      const w = factory(views, path)
+      assertSeachPage(w.vm)
 
-    const index = w.vm.pageIndex
-    expect(index.num).toBe(1)
-    expect(index.total).toBe(3)
+      const index = w.vm.pageIndex
+      expect(index.num).toBe(num)
+      expect(index.total).toBe(total)
+    })
   })
 
   test('contentsByPage', () => {

--- a/src/components/templates/SearchPage.vue
+++ b/src/components/templates/SearchPage.vue
@@ -63,9 +63,11 @@ export default class SearchPage extends Vue implements search.SearchProp {
   }
 
   get pageIndex(): { num: number; total: number } {
+    const total = Math.ceil(Math.max(this.matchPages.length, 1) / pagePostCount)
+
     return {
-      num: pageNumber(this.$route.query.page?.toString()),
-      total: Math.ceil(this.matchPages.length / pagePostCount),
+      num: Math.min(pageNumber(this.$route.query.page?.toString()), total),
+      total,
     }
   }
 


### PR DESCRIPTION
検索に一致した記事が見つからなかった場合のページ番号処理に不具合があったのを修正。
総ページの最低値は `0` 、現在ページの最大値が総ページになるように修正。