### PR TITLE
fix: デプロイ用ブランチを `gh-pages` から変更

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: github pages
+name: deploy
 
 on:
   push:
@@ -94,6 +94,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          publish_branch: deploy
           publish_dir: ./dist
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vlife-blog
 
-![deploy](https://github.com/akiakishitai/vlife-blog/workflows/github%20pages/badge.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/189e1279-c25a-46d0-956d-27f785d3d88d/deploy-status)](https://app.netlify.com/sites/vlike-vlife/deploys)
+![deploy](https://github.com/akiakishitai/vlife-blog/workflows/deploy/badge.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/189e1279-c25a-46d0-956d-27f785d3d88d/deploy-status)](https://app.netlify.com/sites/vlike-vlife/deploys)
 
 > Generate a static site with Nuxt.js
 


### PR DESCRIPTION
公開先を _Netlify_ へ変更したので _GitHub Pages_ を停止したい。
停止するためには `gh-pages` ブランチを削除する必要があるため、デプロイ用のブランチを `deploy` に変更。

link #185 