### PR TITLE
feat: Atomフィードを作成

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,10 +7,10 @@ const routerBase =
 const isDeploy = process.env.DEPLOY_ENV === 'GH_PAGES'
 
 /** デプロイ先のホスト */
-const host = join(
-  isDeploy ? 'https://vlike-vlife.netlify.app' : 'http://localhost:3000',
-  routerBase
-)
+const host = new URL(
+  routerBase,
+  isDeploy ? 'https://vlike-vlife.netlify.app' : 'http://localhost:3000'
+).toString()
 
 /** @type {import('@nuxt/types').NuxtConfig} */
 const conf = {
@@ -87,6 +87,23 @@ const conf = {
       {
         dynamicRoot: ['/posts'],
         excludes: ['/posts', '/posts/demo'],
+      },
+    ],
+    [
+      '@/modules/feedGenerator',
+      {
+        includes: ['/posts'],
+        excludes: ['/posts', '/posts/demo'],
+        asciidocDir: join(__dirname, 'src/outsides/asciidocs/source'),
+        feedOptions: {
+          title: 'Vがいる生活',
+          siteUrl: host,
+          domain: new URL(host).hostname,
+          domainDate: '2020-11',
+          author: {
+            name: '秋々すすき',
+          },
+        },
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@nuxtjs/tailwindcss": "^3.0.0",
     "@types/jest": "^26.0.0",
     "@types/jsdom": "^16.2.5",
+    "@types/nunjucks": "^3.1.3",
     "@types/prismjs": "^1.16.1",
     "@types/simple-icons": "^2.5.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",

--- a/src/components/organisms/FooterBar.spec.ts
+++ b/src/components/organisms/FooterBar.spec.ts
@@ -14,5 +14,8 @@ describe('FooterBar', () => {
     expect(wrapper.find('nuxt-link-stub[to="/privacy-policy"]').text()).toBe(
       'プライバシーポリシー'
     )
+    expect(
+      wrapper.find('li > a[href*="atom.xml"] > .material-icons').exists()
+    ).toBeTruthy()
   })
 })

--- a/src/components/organisms/FooterBar.vue
+++ b/src/components/organisms/FooterBar.vue
@@ -1,6 +1,6 @@
 <template>
   <footer class="footerbar">
-    <ul class="flex justify-center">
+    <ul class="flex justify-center items-center">
       <li><nuxt-link class="p-2 block" to="/">Home</nuxt-link></li>
       <li>
         <nuxt-link class="p-2 block" to="/contact">お問い合わせ</nuxt-link>
@@ -9,6 +9,11 @@
         <nuxt-link class="p-2 block" to="/privacy-policy"
           >プライバシーポリシー</nuxt-link
         >
+      </li>
+      <li class="mx-4 absolute right-0">
+        <a class="p-2 block" href="/feeds/atom.xml" title="atom 1.0">
+          <span class="material-icons">rss_feed</span>
+        </a>
       </li>
     </ul>
   </footer>

--- a/src/modules/feedGenerator/__test__/template.spec.ts
+++ b/src/modules/feedGenerator/__test__/template.spec.ts
@@ -1,0 +1,87 @@
+import { resolve } from 'path'
+import { configure } from 'nunjucks'
+import { JSDOM } from 'jsdom'
+
+describe('nunjucks template', () => {
+  const feed = {
+    title: 'Feed test',
+    url: 'http://example.com',
+    updated: '2020-11-22T12:34:56Z',
+    id: {
+      domain: 'sample.co.jp',
+      date: '2011-01',
+      uri: '/hoge/foo/feed',
+    },
+    author: {
+      name: 'Alice',
+    },
+    entries: [
+      {
+        title: 'Entry Test 1',
+        url: 'http://example.com/bar/entry-1',
+        updated: '2020-10-31T23:59:59Z',
+        id: {
+          domain: 'sample.co.jp',
+          date: '2020-10-23',
+          uri: '/bar/entry-1',
+        },
+        author: {
+          name: 'Bob',
+          uri: 'http://bob.yey.com',
+          email: 'bob123@sample.mail',
+        },
+        summary: 'Sample summary.',
+      },
+    ],
+  }
+
+  test('atom.njk', () => {
+    const r = configure({ autoescape: true }).render(
+      resolve(__dirname, '../atom.njk'),
+      {
+        feed,
+      }
+    )
+
+    //console.log(r.replace(/^\s*\n/gm, ''))
+
+    const doc = new JSDOM(r).window.document
+    // atom:feed
+    expect(doc.querySelector('feed>title')?.textContent).toBe(feed.title)
+    const linkAttrs = doc.querySelector('feed>link')?.attributes
+    expect(linkAttrs?.getNamedItem('rel')?.value).toBe('self')
+    expect(linkAttrs?.getNamedItem('href')?.value).toBe(feed.url)
+    expect(doc.querySelector('feed>updated')?.textContent).toBe(feed.updated)
+    expect(doc.querySelector('feed>id')?.textContent).toBe(
+      'tag:sample.co.jp,2011-01:/hoge/foo/feed'
+    )
+    const author = doc.querySelector('feed>author')
+    expect(author?.querySelector('name')?.textContent).toBe(feed.author.name)
+    expect(author?.querySelector('uri')).toBeNull()
+    expect(author?.querySelector('email')).toBeNull()
+
+    // atom:entry
+    const entries = doc.querySelectorAll('feed>entry')
+    entries.forEach((x, idx) => {
+      const orgEntry = feed.entries[idx]
+
+      expect(x.querySelector('title')?.textContent).toBe(orgEntry.title)
+      expect(x.querySelector('link')?.getAttribute('rel')).toBe('alternate')
+      expect(x.querySelector('link')?.getAttribute('href')).toBe(orgEntry.url)
+      expect(x.querySelector('updated')?.textContent).toBe(orgEntry.updated)
+      expect(x.querySelector('id')?.textContent).toBe(
+        'tag:sample.co.jp,2020-10-23:/bar/entry-1'
+      )
+      expect(x.querySelector('author>name')?.textContent).toBe(
+        orgEntry.author.name
+      )
+      expect(x.querySelector('author>uri')?.textContent).toBe(
+        orgEntry.author.uri
+      )
+      expect(x.querySelector('author>email')?.textContent).toBe(
+        orgEntry.author.email
+      )
+      expect(x.querySelector('summary')?.textContent).toBe(orgEntry.summary)
+    })
+  })
+})

--- a/src/modules/feedGenerator/atom.njk
+++ b/src/modules/feedGenerator/atom.njk
@@ -1,0 +1,45 @@
+{%- macro generateId(id) -%}
+  tag:{{ id.domain }},{{ id.date }}:{{ id.uri }}
+{%- endmacro -%}
+
+{# atom:author 要素 #}
+{% macro author(item) -%}
+  <author><name>{{ item.name }}</name>
+    {%- if item.uri != null -%}
+      <uri>{{ item.uri }}</uri>
+    {%- endif -%}
+    {%- if item.email != null -%}
+      <email>{{ item.email }}</email>
+    {%- endif -%}
+  </author>
+{%- endmacro %}
+
+{# Atomフィードのテンプレート #}
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="ja">
+
+  <title>{{ feed.title }}</title>
+  <link rel="self" href="{{ feed.url }}" />
+  <updated>{{ feed.updated }}</updated>
+  <id>{{ generateId(feed.id) }}</id>
+  {{ author(feed.author) if feed.author != null }}
+
+{%- for item in feed.entries %}
+  <entry>
+    <title>{{ item.title }}</title>
+    <link rel="alternate" href="{{ item.url }}" />
+    <updated>{{ item.updated }}</updated>
+    <id>{{ generateId(item.id) }}</id>
+    {{ author(item.author) if item.author != null }}
+
+    {% if item.summary != null -%}
+      <summary>{{ item.summary }}</summary>
+    {%- endif %}
+
+    {% if item.published != null -%}
+      <published>{{ item.published }}</published>
+    {%- endif %}
+  </entry>
+{%- endfor %}
+
+</feed>

--- a/src/modules/feedGenerator/generator.ts
+++ b/src/modules/feedGenerator/generator.ts
@@ -1,0 +1,180 @@
+import { promises as fs } from 'fs'
+import { basename, dirname, extname, join, resolve } from 'path'
+import { configure } from 'nunjucks'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import Processor from '@asciidoctor/core'
+
+dayjs.extend(utc)
+
+export const FeedGenerator: import('@nuxt/types').Module<import('.').FeedGeneratorOptions> = function (
+  options
+) {
+  const processor = Processor()
+  // AsciiDocソースファイル
+  const asciidocs = fs
+    .readdir(options.asciidocDir, {
+      withFileTypes: true,
+      encoding: 'utf-8',
+    })
+    .then((xs) =>
+      xs
+        .filter(
+          (x) => x.isFile() && ['.asciidoc', '.adoc'].includes(extname(x.name))
+        )
+        .map((x) => {
+          const doc = processor.loadFile(join(options.asciidocDir, x.name))
+          return {
+            title: doc.getTitle(),
+            fileName: basename(x.name, extname(x.name)),
+            createdAt: dayjs(doc.getAttribute('created_at')).format(),
+            updatedAt: dayjs(doc.getRevisionDate()).format(),
+            authorName: doc.getAuthor(),
+            summary: doc.getAttribute('summary', undefined) as
+              | string
+              | undefined,
+          }
+        })
+    )
+
+  // ref: https://github.com/nuxt/nuxt.js/blob/dev/packages/generator/src/generator.js
+  this.nuxt.hook(
+    'generate:done',
+    async (generator: import('.').NuxtGenerator) => {
+      console.log('ℹ Generating atom:feed')
+
+      const routes = matchRoutes(
+        Array.from(generator.generatedRoutes),
+        options.includes,
+        options.excludes
+      )
+
+      // generate時に生成されるディレクトリ
+      const distDir = resolve(
+        this.options.rootDir,
+        this.options.generate.dir ?? ''
+      )
+
+      // atom:entry
+      const adocs = await asciidocs
+      const entries: import('.').AtomEntry[] = routes.reduce((prev, curr) => {
+        const adoc = adocs.find((x) => x.fileName === basename(curr))
+        if (adoc != null) {
+          prev.push({
+            title: adoc.title,
+            url: joinUrl(options.feedOptions.siteUrl, curr),
+            updated: adoc.updatedAt,
+            summary: adoc.summary,
+            published: adoc.createdAt,
+            id: createAtomId(
+              options.feedOptions.domain,
+              dayjs(adoc.createdAt).format('YYYY-MM-DD'),
+              join('posts', adoc.fileName)
+            ),
+            author: {
+              name: adoc.authorName,
+            },
+          })
+        }
+
+        return prev
+      }, [] as import('.').AtomEntry[])
+
+      // Atomフィードのファイルパス
+      const atomUri = 'feeds/atom.xml'
+      // atom:feedの必須要素
+      const atomFeedRequired: import('.').AtomRequired = {
+        title: options.feedOptions.title,
+        url: joinUrl(options.feedOptions.siteUrl, atomUri),
+        updated: dayjs().format(),
+        id: createAtomId(
+          options.feedOptions.domain,
+          options.feedOptions.domainDate,
+          atomUri
+        ),
+      }
+      // atom:feed
+      const feed = createFeed(
+        atomFeedRequired,
+        options.feedOptions.author,
+        entries
+      )
+
+      // ファイル出力
+      const output = join(distDir, atomUri)
+      fs.mkdir(dirname(output)).catch(console.error)
+      fs.writeFile(
+        output,
+        configure({ autoescape: true })
+          .render(join(__dirname, 'atom.njk'), {
+            feed,
+          })
+          .replace(/^\s*\n/gm, ''),
+        {
+          encoding: 'utf-8',
+        }
+      )
+        .then((_) => console.log(`Generated ${join('/', atomUri)}`))
+        .catch(console.error)
+    }
+  )
+}
+
+/**
+ * ルートパス配列から含めるパス・除外するパスを処理したあとのルートを返す。
+ * @param routes 処理対象とする全ルートのパス。
+ * @param includes 含めるルートパス。デフォルトで全てが対象（`/`）
+ * @param excludes 除外するルートパス。
+ */
+function matchRoutes(
+  routes: string[],
+  includes: (string | RegExp)[] = ['/'],
+  excludes: string[] = []
+) {
+  return routes
+    .filter((route) => includes.some((x) => route.match(x) != null))
+    .filter((route) => !excludes.includes(route))
+}
+
+function isUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol.match(/https?:/) != null
+  } catch (error) {
+    return false
+  }
+}
+
+function joinUrl(base: string, ...paths: string[]) {
+  return join(base, ...paths).replace(/^(.+):\//, '$1://')
+}
+
+function createAtomId(
+  domain: string,
+  date: string,
+  uri: string
+): import('.').AtomId {
+  const _domain = isUrl(domain)
+    ? new URL(domain).hostname
+    : domain.replace(/^\//, '').split('/')[0]
+
+  return {
+    domain: _domain,
+    date,
+    uri,
+  }
+}
+
+function createFeed(
+  required: import('.').AtomRequired,
+  author: import('.').AtomAuthor,
+  entries: import('.').AtomEntry[]
+): import('.').AtomFeed {
+  const feed: import('.').AtomFeed = {
+    ...required,
+    author,
+    entries,
+  }
+
+  return feed
+}

--- a/src/modules/feedGenerator/index.ts
+++ b/src/modules/feedGenerator/index.ts
@@ -1,0 +1,4 @@
+import { FeedGenerator } from './generator'
+export * from './models'
+
+export default FeedGenerator

--- a/src/modules/feedGenerator/models.ts
+++ b/src/modules/feedGenerator/models.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * @nuxt/generator のクラス。
+ *
+ * ref: https://github.com/nuxt/nuxt.js/blob/v2.14.7/packages/generator/src/generator.js
+ */
+export interface NuxtGenerator {
+  /** nuxt instance */
+  nuxt: any
+  /** nuxt config */
+  options: any
+  builder: any
+
+  // Set variables
+  isFullStatic: boolean
+  /** staticディレクトリへの絶対パス */
+  staticRoutes: string
+  /**
+   * <ビルドディレクトリ>/dist/client への絶対パス。
+   * `generate` 時に `this.distNuxtPath` (dist/_nuxt)へとコピーされる。
+   *
+   * ref: https://github.com/nuxt/nuxt.js/blob/v2.14.7/packages/generator/src/generator.js#L246
+   */
+  srcBuiltPath: string
+  /** generate時の出力ディレクトリパス */
+  distPath: string
+  /** アセット出力するパス。publicPathがURLのときはdistPathと同じ値。 */
+  distNuxtPath: string
+
+  // Payloads for full static
+  /** 静的アセットディレクトリへの絶対パス */
+  staticAssetsDir: string
+  /** 静的アセットのURLルート */
+  staticAssetsBase: string
+  // Shared payload
+  setPayload: typeof Function
+
+  // Routes
+  /** 自動生成したルート */
+  generatedRoutes: Set<string>
+}
+
+/**
+ * FeedGenerator用のオプション
+ */
+export interface FeedGeneratorOptions {
+  /** 対象とするルートのパターン */
+  includes?: (string | RegExp)[]
+  /** 除外するルートの相対パス */
+  excludes?: string[]
+  /** asciidocディレクトリパス */
+  asciidocDir: string
+
+  feedOptions: {
+    title: string
+    siteUrl: string
+    domain: string
+    domainDate: string
+    author: AtomAuthor
+  }
+}
+
+/**
+ * Atomフィードにおける必須要素
+ */
+export interface AtomRequired {
+  title: string
+  url: string
+  /** ISO 8601 形式 */
+  updated: string
+  id: AtomId
+}
+
+export interface AtomId {
+  /** ドメインまたはe-mailアドレス */
+  domain: string
+  /** ISO 8601 形式 */
+  date: string
+  uri: string
+}
+
+/**
+ * Atomフィードにおけるauthor要素
+ */
+export interface AtomAuthor {
+  /** 作成者名 */
+  name: string
+  uri?: string
+  email?: string
+}
+
+/**
+ * atom:feed要素
+ */
+export interface AtomFeed extends AtomRequired {
+  author: AtomAuthor
+  entries: AtomEntry[]
+}
+
+export interface AtomEntry extends AtomRequired {
+  author?: AtomAuthor
+  summary?: string
+  /** ISO 8601 形式 */
+  published?: string
+}

--- a/src/pages/posts/_slug/index.vue
+++ b/src/pages/posts/_slug/index.vue
@@ -64,6 +64,14 @@ export default Vue.extend({
           content: prop.tags.join(','),
         },
       ],
+      link: [
+        {
+          rel: 'alternate',
+          type: 'application/atom+xml',
+          href: '/feeds/atom.xml',
+          title: 'Atom 1.0',
+        },
+      ],
     }
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,6 +2372,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/nunjucks@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.1.3.tgz#55fa2bf6fd34641545a6686217324fde66d31164"
+  integrity sha512-42IiIIBdoB7ZDwCVhCWYT4fMCj+4TeacuVgh7xyT2du5EhkpA+OFeeDdYTFCUt1MrHb8Aw7ZqFvr8s1bwP9l8w==
+
 "@types/optimize-css-assets-webpack-plugin@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz#1f437ef9ef937b393687a8819be2d2fddc03b069"


### PR DESCRIPTION
_Google Search Console_ 登録用にAtomフィードを作成。
投稿記事に対して自動生成するようにモジュールを作成。

- chore: install types of nunjucks
- feat: create the module of atom feed
- chore: add module
- fix: fix to join URL
- feat: add link to atom feed in head and footer

close #203