### PR TITLE
fix: redirect to home from '/posts' route

### DIFF
--- a/src/pages/posts/index.vue
+++ b/src/pages/posts/index.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>redirect to home.</div>
+</template>
+
+<script lang="ts">
+import { Context } from '@nuxt/types'
+import { Component, Prop, Vue } from 'nuxt-property-decorator'
+
+@Component
+export default class index extends Vue {
+  async asyncData(ctx: Context) {
+    return ctx.redirect('/')
+  }
+}
+</script>


### PR DESCRIPTION
`nuxt generate` 時に自動クローラーを利用していると、ページを用意していない `/posts` ルートでエラーが発生して処理が中断されて後続のページがルーティングされない。
これを回避するため、トップページへリダイレクトするだけのページを実装した。