### PR TITLE
fix: env context only use name, with key and if in steps

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global credential.helper "$CREDENTIAL_HELPER_PATH/git-credential-github-token"
           yarn run update-articles
         env:
-          CREDENTIAL_HELPER_PATH: ${{ env.GITHUB_WORKSPACE }}/.github/bin
+          CREDENTIAL_HELPER_PATH: ${{ github.workspace }}/.github/bin
           CREDENTIAL_USERNAME: ${{ github.actor }}
           CREDENTIAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 


### PR DESCRIPTION
`env` コンテキストが利用できるのは `name` や `with` キーの値、またはステップ中の `if` 条件式の中だけだったので修正。
（[参考](https://docs.github.com/ja/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#env%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88)）