### PR TITLE
fix: fix command to submodule update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global credential.helper "$CREDENTIAL_HELPER_PATH/git-credential-github-token"
           yarn run update-articles
         env:
-          CREDENTIAL_HELPER_PATH: ${{ env.GITHUB_WORKSPACE }}/.github/bin
+          CREDENTIAL_HELPER_PATH: ${{ github.workspace }}/.github/bin
           CREDENTIAL_USERNAME: ${{ github.actor }}
           CREDENTIAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "nuxt start",
     "test": "jest --runInBand",
     "test-ci": "jest --runInBand --coverage false",
-    "update-articles": "git submodule update --remote --merge"
+    "update-articles": "git submodule update --remote"
   },
   "dependencies": {
     "@asciidoctor/core": "^2.2.0",


### PR DESCRIPTION
`--merge` オプションを付けていると `fatal: refusing to merge unrelated histories` エラーが発生しているので取り除いた。
`--remote` オプションだけでもサブモジュールのリポジトリのフェッチおよびマージをするらしい。