### PR TITLE
style: set styles of details and callouts

### DIFF
--- a/.vscode/_asciidoc-theme.scss
+++ b/.vscode/_asciidoc-theme.scss
@@ -1,5 +1,6 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 
 @import '../src/assets/css/post/post-body';
 

--- a/src/assets/css/post/_base.scss
+++ b/src/assets/css/post/_base.scss
@@ -98,3 +98,17 @@ pre {
   @apply relative rounded;
   @apply py-4 px-6;
 }
+
+/* 折りたたみ */
+details {
+  @apply mt-4;
+
+  & > summary {
+    @apply cursor-pointer;
+  }
+
+  & > :not(summary) {
+    @apply pl-4;
+    @apply border-grey-500 border-l-2 border-opacity-54;
+  }
+}

--- a/src/assets/css/post/_post-body.scss
+++ b/src/assets/css/post/_post-body.scss
@@ -256,13 +256,29 @@ table.tableblock,
 /* Callouts description */
 .colist {
   > ol {
-    @apply mt-0;
+    @apply mt-0 pl-4;
+    @apply list-none;
+
+    counter-reset: callout-num;
   }
   li {
     @apply mt-1;
-  }
-  li:first-of-type {
-    @apply mt-0;
+    @apply grid gap-2;
+
+    grid-template-columns: 24px 1fr;
+
+    &:first-of-type {
+      @apply mt-0;
+    }
+
+    &::before {
+      @apply w-6 h-6;
+      @apply block text-center text-grey-200;
+      @apply rounded-full bg-secondary;
+
+      content: counter(callout-num);
+      counter-increment: callout-num;
+    }
   }
 }
 

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -54,5 +54,5 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: ['./**/*.html', './**/*.vue'],
+  purge: ['./**/*.html', './**/*.vue', './**/*.adoc'],
 }


### PR DESCRIPTION
`details` タグと _Callouts_ 用のCSSを修正。
また _TailwindCSS_ が `.adoc` ファイルでもクラス名をチェックするように変更。

- fix: add tailwindcss classes on vscode preview
- fix: add .adoc file pathes
- style: add styles of details
- style: set callouts style