### PR TITLE
fix: set the canonical to avoid duplicate url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -180,6 +180,7 @@ const conf = {
    */
   generate: {
     fallback: true,
+    subFolders: false,
   },
   /*
    ** Nuxt source directory

--- a/src/helpers/functions.spec.ts
+++ b/src/helpers/functions.spec.ts
@@ -1,4 +1,9 @@
-import { isObject, encodePathURI, naviArticleFrontBack } from './functions'
+import {
+  isObject,
+  encodePathURI,
+  naviArticleFrontBack,
+  fullUrl,
+} from './functions'
 
 describe('Functions', () => {
   test('of isObject', () => {
@@ -67,5 +72,14 @@ describe('Functions', () => {
     ],
   ])('does naviArticleFrontBack(%s)', (route, names, expected) => {
     expect(naviArticleFrontBack(route, names)).toEqual(expected)
+  })
+
+  // fullUrl
+  test.each([
+    ['/hoge', undefined, 'http://localhost:3000/hoge'],
+    ['/foo/bar', undefined, 'http://localhost:3000/foo/bar'],
+    ['/hoge', 'https://www.example.com', 'https://www.example.com/hoge'],
+  ])('fullUrl', (path, fqdn, url) => {
+    expect(fullUrl(path, fqdn)).toEqual(url)
   })
 })

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -10,6 +10,22 @@ export function isObject(x: unknown): x is Record<string, unknown> {
 }
 
 /**
+ * 現在ページの完全URLを返す。クエリパラメータは含まれない。
+ * 環境変数 NUXT_ENV_BASEURL に HTTPプロトコルからの FQDN（ホスト名＋ドメイン） を入力しておく。
+ * 存在しない場合は `http://localhost:3000` がデフォルトとなる。
+ *
+ * @param routePath URLのパス。
+ * @param fallbackFQDN 環境変数 `NUXT_ENV_BASEURL` が存在しない場合のフォールバック。
+ */
+export function fullUrl(
+  routePath: string,
+  fallbackFQDN = 'http://localhost:3000'
+): string {
+  const baseUrl = new URL(process.env.NUXT_ENV_BASEURL ?? fallbackFQDN)
+  return new URL(routePath.replace(/^\//, ''), baseUrl).href
+}
+
+/**
  * パスに対してURIエンコード処理を行った結果を返す。
  * 完全なURIに対してのエンコード処理は未対応。
  *

--- a/src/pages/posts/_slug/index.vue
+++ b/src/pages/posts/_slug/index.vue
@@ -7,12 +7,13 @@
 </template>
 
 <script lang="ts">
+import { join } from 'path'
 import Vue, { ComponentOptions } from 'vue'
 import ArticlePosted from '@/components/templates/ArticlePosted.vue'
 import { ArticleNavigation } from '../../../models'
 import { naviFrontBack } from './asyncData'
 import { AsciidocParsed } from '~/modules/asciidocPresenter'
-import { join } from 'path'
+import { fullUrl } from '~/helpers/functions'
 
 type Property = {
   posted: AsciidocParsed
@@ -46,7 +47,7 @@ export default Vue.extend({
         (await asciidoc.filesByPage()).overviews,
         ctx.route.path
       ),
-      currentPath: new URL(ctx.route.path.replace(/^\//, ''), baseUrl).href,
+      currentPath: fullUrl(ctx.route.path),
     }
   },
   mounted() {
@@ -72,6 +73,10 @@ export default Vue.extend({
           type: 'application/atom+xml',
           href: '/feeds/atom.xml',
           title: 'Atom 1.0',
+        },
+        {
+          rel: 'canonical',
+          href: fullUrl(this.$route.path).replace(/\/$/, ''),
         },
       ],
     }

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -6,6 +6,7 @@
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
 import { SearchProp } from '~/models/vueProperties/searchPageProps'
 import SearchPage from '../../components/templates/SearchPage.vue'
+import { fullUrl } from '~/helpers/functions'
 
 @Component({
   components: {
@@ -29,6 +30,12 @@ import SearchPage from '../../components/templates/SearchPage.vue'
   head() {
     return {
       title: '検索',
+      link: [
+        {
+          rel: 'canonical',
+          href: fullUrl(this.$route.path).replace(/\/$/, ''),
+        },
+      ],
     }
   },
 })


### PR DESCRIPTION
重複URLを統合するために `canonical` 属性で正規URLを指定した。
また正規URLは末尾のスラッシュがないものとしたため、`nuxt.config.js` で `generate` プロパティの `subFolders` を `false` にした。

close #228