### PR TITLE
fix: redirect by middleware

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -174,6 +174,7 @@ const conf = {
    */
   router: {
     base: routerBase,
+    trailingSlash: false,
   },
   /**
    * Generate route

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { redirectFromTailSlash } from '../middleware/redirect'
 import FooterBar from '../components/organisms/FooterBar.vue'
 import TopAppBar from '../components/organisms/TopAppBar.vue'
 
@@ -18,6 +19,7 @@ export default Vue.extend({
     FooterBar,
     TopAppBar,
   },
+  middleware: [redirectFromTailSlash],
 })
 </script>
 

--- a/src/middleware/redirect.ts
+++ b/src/middleware/redirect.ts
@@ -1,0 +1,14 @@
+import { Middleware } from '@nuxt/types'
+
+/**
+ * ルート以外のページでURLパスの末尾が `/` の場合、`/` なしのページへリダイレクトする
+ */
+export const redirectFromTailSlash: Middleware = async ({
+  route: { path },
+  redirect,
+}) => {
+  const tailSlash = new RegExp('/$')
+  if (path !== '/' && tailSlash.test(path)) {
+    return redirect(301, path.replace(tailSlash, ''))
+  }
+}

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -10,17 +10,35 @@
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
+import { Context } from '@nuxt/types'
+import { MetaInfo } from 'vue-meta'
 import { join } from 'path'
 import TopPage from '../components/templates/TopPage.vue'
 import { PagingContent, PostFile, TopPageProps } from '@/models'
 import { AsciidocParsed } from '~/modules/asciidocPresenter'
+import { fullUrl } from '~/helpers/functions'
+
+type PageUrl = { pageUrl: string }
 
 @Component({
   watchQuery: ['page'],
+  components: {
+    TopPage,
+  },
+})
+export default class Home extends Vue {
+  pageIndex = { num: 1, total: 1 }
+
+  get isFirstPage() {
+    return this.pageIndex.num === 1
+  }
+
   // クエリパラメータでページネーション
   async asyncData(
-    ctx
-  ): Promise<TopPageProps.ContentsProp & TopPageProps.PaginationProp> {
+    ctx: Context
+  ): Promise<
+    TopPageProps.ContentsProp & TopPageProps.PaginationProp & PageUrl
+  > {
     const page = parseInt(ctx.query.page?.toString() ?? '1', 10)
     const contents = await ctx.app.$asciidoc.filesByPage(page)
     const postRoute = join(ctx.route.path, 'posts')
@@ -35,12 +53,11 @@ import { AsciidocParsed } from '~/modules/asciidocPresenter'
         pagination: postRoute,
         post: postRoute,
       },
+      pageUrl: fullUrl(ctx.route.path),
     }
-  },
-  components: {
-    TopPage,
-  },
-  head: () => {
+  }
+
+  head(): MetaInfo {
     return {
       title: 'Home',
       meta: [
@@ -50,14 +67,8 @@ import { AsciidocParsed } from '~/modules/asciidocPresenter'
           hid: 'google-site-verification',
         },
       ],
+      link: [{ rel: 'canonical', href: this.$data.pageUrl ?? 'failed' }],
     }
-  },
-})
-export default class Home extends Vue {
-  pageIndex = { num: 1, total: 1 }
-
-  get isFirstPage() {
-    return this.pageIndex.num === 1
   }
 }
 </script>

--- a/src/pages/posts/_slug/index.vue
+++ b/src/pages/posts/_slug/index.vue
@@ -36,11 +36,6 @@ export default Vue.extend({
   async asyncData(ctx): Promise<Property> {
     const asciidoc = ctx.app.$asciidoc
 
-    // base URL
-    const baseUrl = new URL(
-      process.env.NUXT_ENV_BASEURL ?? 'http://localhost:3000'
-    )
-
     return {
       posted: await asciidoc.content(ctx.params.slug),
       navi: naviFrontBack(
@@ -73,10 +68,6 @@ export default Vue.extend({
           type: 'application/atom+xml',
           href: '/feeds/atom.xml',
           title: 'Atom 1.0',
-        },
-        {
-          rel: 'canonical',
-          href: fullUrl(this.$route.path).replace(/\/$/, ''),
         },
       ],
     }

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -4,16 +4,24 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Context } from '@nuxt/types'
+import { MetaInfo } from 'vue-meta'
 import { SearchProp } from '~/models/vueProperties/searchPageProps'
 import SearchPage from '../../components/templates/SearchPage.vue'
 import { fullUrl } from '~/helpers/functions'
+
+type PageUrl = { pageUrl: string }
 
 @Component({
   components: {
     SearchPage,
   },
   watchQuery: ['page', 'tags'],
-  async asyncData(ctx): Promise<Pick<SearchProp, 'contents'>> {
+})
+export default class Search extends Vue {
+  async asyncData(
+    ctx: Context
+  ): Promise<Pick<SearchProp, 'contents'> & PageUrl> {
     // 全ての概要ページ
     const contents = await ctx.app.$asciidoc.filesByPage(0)
 
@@ -25,21 +33,22 @@ import { fullUrl } from '~/helpers/functions'
 
     return {
       contents,
+      pageUrl: fullUrl(ctx.route.path),
     }
-  },
-  head() {
+  }
+
+  head(): MetaInfo {
     return {
       title: '検索',
       link: [
         {
           rel: 'canonical',
-          href: fullUrl(this.$route.path).replace(/\/$/, ''),
+          href: this.$data.pageUrl,
         },
       ],
     }
-  },
-})
-export default class Search extends Vue {}
+  }
+}
 </script>
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
末尾スラッシュなしのURLを正規ページにするため、リダイレクトを使う手法に修正。

リダイレクトは `middleware` を利用し、`layouts` で利用することで全ページを対象にした。
また `nuxt.config.js` において `trailingSlash: false` とすることで末尾スラッシュURLを無効化しておき、
スラッシュありURLはなしURLページへとリダイレクトするようにした。

クエリパラメータを利用するページにおいては、`canonical` 属性を利用したままとした。
ただし、正規URLを固定化したいので、URL生成を `asyncData` メソッドで行うよう修正した。
