### PR TITLE
feat: use icon font in asciidoc

### DIFF
--- a/src/assets/css/post/_common.scss
+++ b/src/assets/css/post/_common.scss
@@ -19,6 +19,11 @@
   }
 }
 
+/** Monospace font */
+%monospace {
+  font-family: 'Roboto Mono', monospace;
+}
+
 %table-halign {
   &.halign-center {
     @apply text-center;

--- a/src/assets/css/post/_mixin.scss
+++ b/src/assets/css/post/_mixin.scss
@@ -9,9 +9,7 @@
     @apply border-#{$tailwind-color};
     @apply bg-#{$tailwind-color} bg-opacity-15;
 
-    .title {
-      @apply text-#{$tailwind-color};
-    }
+    @apply text-#{$tailwind-color};
   }
 }
 

--- a/src/assets/css/post/_post-body.scss
+++ b/src/assets/css/post/_post-body.scss
@@ -200,6 +200,15 @@ table.tableblock,
       @extend %material-icon-prefix;
       @apply flex justify-center;
     }
+
+    .fa[data-md-icon]::before {
+      @extend %material-icon-font;
+
+      @apply block text-center;
+      @apply mr-0;
+
+      content: attr(data-md-icon);
+    }
   }
 
   .content .title {
@@ -217,7 +226,7 @@ table.tableblock,
     @include mixin.icon_prefix(teal-400);
   }
   &.important {
-    @include mixin.icon_prefix(green-600);
+    @include mixin.icon_prefix(purple-500);
   }
   &.caution {
     @include mixin.icon_prefix(orange-600);
@@ -280,6 +289,42 @@ table.tableblock,
       counter-increment: callout-num;
     }
   }
+}
+// Callouts in icon-font
+// 丸数字
+%callout-number {
+  @extend %monospace;
+  @apply inline-flex justify-center items-center;
+  @apply not-italic text-white text-opacity-87;
+  @apply rounded-full bg-secondary;
+}
+pre .conum[data-value] {
+  &::before {
+    @extend %callout-number;
+    @apply w-5 h-5;
+    @apply text-sm;
+
+    content: attr(data-value);
+  }
+}
+.colist {
+  > table {
+    @appy mt-0;
+
+    > tbody > tr > td:last-of-type {
+      @apply pl-0;
+    }
+  }
+
+  .conum[data-value]::before {
+    @extend %callout-number;
+    @apply w-6 h-6;
+
+    content: attr(data-value);
+  }
+}
+.conum + b {
+  display: none;
 }
 
 /* Image inline */

--- a/src/plugins/prism.ts
+++ b/src/plugins/prism.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { highlightAll } from 'prismjs'
+import Prism from 'prismjs'
 //import 'prismjs/themes/prism-okaidia.css'
 import 'prism-themes/themes/prism-material-dark.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers'
@@ -22,20 +22,70 @@ import 'prismjs/components/prism-toml'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-yaml'
 
+interface PrismHighlight {
+  /**
+   * {@link highlightAll} 関数を提供する。
+   */
+  highlightAll: typeof Prism.highlightAll
+}
+
 // VueインスタンスにInject
 declare module 'vue/types/vue' {
   interface Vue {
     /**
      * Prismの関数を提供する。
      */
-    $prism: {
-      /**
-       * {@link highlightAll} 関数を提供する。
-       */
-      highlightAll: typeof highlightAll
-    }
+    $prism: PrismHighlight
   }
 }
 
+/**
+ * Prismによるハイライトを実行したときでも、AsciiDocのCalloutsタグをそのまま維持する `Prism.hooks` を追加する。
+ */
+function keepHighlight() {
+  // keep tags of callouts
+  const stashes = new Set<number>()
+  const placeholder = (id: number) => `___CALLOUTS_${id}___`
+  const token = (value: number) => `<i class="conum" data-value="${value}"></i>`
+
+  // AsciiDocのCalloutsタグを一時退避して、Prismjsによるサニタイズを回避する
+  // https://github.com/PrismJS/prism/issues/558
+  Prism.hooks.add('before-highlight', (env) => {
+    // callouts number regexp
+    const pattern = new RegExp(
+      `${token(0).replace('0', '(\\d+)')}<b>[^<]*</b>`,
+      'g'
+    )
+
+    if (!pattern.test(env.element.innerHTML)) {
+      return
+    }
+
+    const code = env.element.innerHTML.replace(pattern, (match, p1: number) => {
+      stashes.add(p1)
+      return placeholder(p1)
+    })
+
+    env.element.innerHTML = code
+    env.code = code
+  })
+
+  // 一時退避したCalloutsタグをもとに戻す
+  Prism.hooks.add('after-highlight', (env) => {
+    stashes.forEach((id) => {
+      const code = env.highlightedCode.replace(
+        new RegExp(placeholder(id), 'g'),
+        token(id)
+      )
+
+      env.highlightedCode = code
+      env.element.innerHTML = code
+    })
+  })
+}
+keepHighlight()
+
 // 実装
-Vue.prototype.$prism = { highlightAll: highlightAll }
+Vue.prototype.$prism = {
+  highlightAll: Prism.highlightAll,
+}


### PR DESCRIPTION
Keep html elements of asciidoc callouts in icon font.
Add styles for icon font.

アイコンフォントを利用するためCSSを修正。
またその際に _AsciiDoc_ が `<code>` 要素内に生成する _Callouts_ 要素が、`prismjs` によって消去されないようにフック関数を追加した。