### PR TITLE
refactor: control not index pages

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -142,7 +142,7 @@ const conf = {
   sitemap: {
     hostname: host,
     gzip: true,
-    exclude: ['/secret', '/admin/**', '/license'],
+    exclude: ['/secret', '/admin/**', '/license', '/contact', '/search'],
     xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
   },
   /*

--- a/src/components/molecules/TagColumn.vue
+++ b/src/components/molecules/TagColumn.vue
@@ -1,16 +1,19 @@
 <template functional>
   <div class="mdc-chip-set" role="table">
-    <nuxt-link
+    <button
       v-for="(item, index) in $options.methods.skipEmpty(props.tags)"
       :key="index"
-      :to="$options.methods.searchTagsLink(item.value)"
+      type="button"
+      @click="
+        listeners['move-page']('/search', { page: '1', tags: item.value })
+      "
     >
       <component
         v-bind:is="injections.components.TagChip"
         v-bind:tag="item.name"
         v-bind:value="item.value"
       />
-    </nuxt-link>
+    </button>
   </div>
 </template>
 

--- a/src/components/organisms/OverviewArticle.vue
+++ b/src/components/organisms/OverviewArticle.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative text-left">
-    <nuxt-link class="link-article" v-bind:to="linkToArticle">
+    <nuxt-link class="link-article" :to="linkToArticle">
       <div class="flex">
         <!-- 画像 -->
         <span
@@ -19,24 +19,25 @@
 
     <!-- タグ一覧 -->
     <div class="inline-flex relative z-10 mt-4">
-      <tag-column v-bind:tags="propTags(content)" />
+      <tag-column :tags="propTags(content)" @move-page="movePage" />
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Component, mixins, Prop, Vue } from 'nuxt-property-decorator'
 import { basename, extname, join } from 'path'
 import TagColumn from '../molecules/TagColumn.vue'
 import { ArticleTag, TopPageProps } from '@/models'
 import { encodePathURI } from '@/helpers/functions'
+import { LinkToSearchTags } from '~/mixins/linkToSearchTags'
 
 @Component({
   components: {
     TagColumn,
   },
 })
-export default class OverviewArticle extends Vue {
+export default class OverviewArticle extends mixins(LinkToSearchTags) {
   /**
    * 表示する概要としてMarkdownファイルの情報を用いる。
    */

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="pb-6">
-    <HeadingLevel v-bind:value="headingLevel" />
+    <HeadingLevel :value="headingLevel" />
     <div class="mt-4">
-      <TagColumn v-bind:tags="tags" />
-      <DatesDisplay
-        class="flex justify-end"
-        v-bind:item="article | dateFormats"
-      />
+      <TagColumn :tags="tags" @move-page="movePage" />
+      <DatesDisplay class="flex justify-end" :item="article | dateFormats" />
     </div>
 
     <hr class="mt-2 border-grey-500" />
@@ -14,24 +11,24 @@
     <!-- 要素テスト用 -->
     <div v-if="isDebug(article.tags)" class="flex mt-4">
       <ButtonMaterial />
-      <ButtonMaterial class="ml-4" v-bind:property="{ label: 'hoge' }" />
-      <ButtonMaterial class="ml-4" v-bind:property="{ type: 'outlined' }" />
+      <ButtonMaterial class="ml-4" :property="{ label: 'hoge' }" />
+      <ButtonMaterial class="ml-4" :property="{ type: 'outlined' }" />
       <ButtonMaterial
         class="ml-4"
-        v-bind:property="{ type: 'raised', icon: 'bookmark' }"
+        :property="{ type: 'raised', icon: 'bookmark' }"
       />
     </div>
     <!-- 要素テスト終了 -->
 
     <!-- Markdown記事本文 -->
-    <ArticleBody class="mt-6" v-bind:renderd="article.body" />
+    <ArticleBody class="mt-6" :renderd="article.body" />
 
     <!-- シェアボタン -->
     <div class="share-buttons mt-8">
       <ShareButtonsBar
         class="items-center justify-center"
-        v-bind:url="currentFullPath"
-        v-bind:text="article.title"
+        :url="currentFullPath"
+        :text="article.title"
       />
     </div>
 
@@ -42,7 +39,7 @@
     <ArticlePagination
       v-if="!isDebug(article.tags)"
       class="mt-6"
-      v-bind:navigation="navigation"
+      :navigation="navigation"
     />
   </div>
 </template>
@@ -67,6 +64,7 @@ import ButtonMaterial from '../atoms/ButtonMaterial.vue'
 import ArticlePagination from '../organisms/ArticlePagination.vue'
 import ShareButtonsBar from '../organisms/ShareButtonsBar.vue'
 import { AsciidocParsed } from '~/modules/asciidocPresenter'
+import { LinkToSearchTags } from '~/mixins/linkToSearchTags'
 
 /**
  * _Markdown_ 記事テンプレート。
@@ -99,7 +97,7 @@ import { AsciidocParsed } from '~/modules/asciidocPresenter'
   },
 })
 export default class ArticlePosted
-  extends mixins(DebugMixin)
+  extends mixins(DebugMixin, LinkToSearchTags)
   implements ArticlePageProps.NavigationProp {
   /**
    * 投稿記事のソースファイルの内容。

--- a/src/helpers/globals.ts
+++ b/src/helpers/globals.ts
@@ -5,3 +5,6 @@ export const postRoute = '/posts'
 
 /** 1ページあたりの記事の表示件数 */
 export const pagePostCount = 20
+
+/** noindex メタタグ */
+export const noindex = { name: 'robots', content: 'noindex' }

--- a/src/mixins/linkToSearchTags.spec.ts
+++ b/src/mixins/linkToSearchTags.spec.ts
@@ -1,7 +1,10 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { RawLocation } from 'vue-router'
 import { LinkToSearchTags } from './linkToSearchTags'
 
 describe('LinkToSearchTags', () => {
   const link = new LinkToSearchTags()
+  const mockPush = jest.fn()
 
   test.each([
     [
@@ -12,5 +15,23 @@ describe('LinkToSearchTags', () => {
     [[''], '/search?page=1'],
   ])('apply tags: %s', (tags, result) => {
     expect(link.searchTagsLink(...tags)).toBe(result)
+  })
+
+  test.each([
+    ['/hoge', { page: '1' }],
+    ['/hoge', { page: '2', tags: 'test demo' }],
+    ['/hoge', undefined],
+    ['/hoge/foo', { page: '3', tags: 'sample', id: '123' }],
+  ])('move %s page with %s', (path, query) => {
+    const w = shallowMount(LinkToSearchTags, {
+      mocks: { $router: { push: mockPush } },
+      template: '<div>dummy</div>',
+    })
+
+    w.vm.movePage(path, query)
+    expect(mockPush.mock.calls.length).toBe(1)
+    expect(mockPush.mock.calls[0][0]).toEqual({ path, query })
+
+    mockPush.mockClear()
   })
 })

--- a/src/mixins/linkToSearchTags.ts
+++ b/src/mixins/linkToSearchTags.ts
@@ -15,5 +15,15 @@ export const LinkToSearchTags = Vue.extend({
 
       return `${route}?${params.toString()}`
     },
+
+    /**
+     * ページ遷移を行うだけの関数。
+     *
+     * @param path URLルート相対パス
+     * @param query クエリパラメータ
+     */
+    movePage(path: string, query?: Record<string, string | (string | null)[]>) {
+      return this.$router.push({ path, query })
+    },
   },
 })

--- a/src/pages/contact/index.vue
+++ b/src/pages/contact/index.vue
@@ -8,16 +8,13 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { MetaInfo } from 'vue-meta'
+import { noindex } from '~/helpers/globals'
 import ContactPage from '../../components/templates/ContactPage.vue'
 
 @Component({
   components: {
     ContactPage,
-  },
-  head: () => {
-    return {
-      title: 'お問い合わせ',
-    }
   },
 })
 export default class Contact extends Vue {
@@ -27,6 +24,13 @@ export default class Contact extends Vue {
     const url =
       'aHR0cHM6Ly9zY3JpcHQuZ29vZ2xlLmNvbS9tYWNyb3Mvcy9BS2Z5Y2J5MVpvaU1Hd3ZwZlpIeVd3MVNsRlRrTzd2ZHhKZEh3OVQ2NWp5RHJfZTZZVjZtWXVaRy9leGVj'
     return Buffer.from(url, 'base64').toString()
+  }
+
+  head(): MetaInfo {
+    return {
+      title: 'お問い合わせ',
+      meta: [noindex],
+    }
   }
 }
 </script>

--- a/src/pages/license/index.vue
+++ b/src/pages/license/index.vue
@@ -28,11 +28,20 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'nuxt-property-decorator'
+import { Context } from '@nuxt/types'
+import { MetaInfo } from 'vue-meta'
 import LicensePage from '@/components/templates/LicensePage.vue'
 import LinkWrapper from '@/components/atoms/LinkWrapper.vue'
+import { noindex } from '~/helpers/globals'
 
 @Component({
-  async asyncData(ctx) {
+  components: {
+    LicensePage,
+    LinkWrapper,
+  },
+})
+export default class License extends Vue {
+  async asyncData(ctx: Context) {
     const $http: import('@nuxt/http').NuxtHTTPInstance = ctx.$http
     const res = await $http.get('/txt/thirdparty_license.txt')
     const license = await res.text()
@@ -42,16 +51,15 @@ import LinkWrapper from '@/components/atoms/LinkWrapper.vue'
         library: license,
       },
     }
-  },
-  components: {
-    LicensePage,
-    LinkWrapper,
-  },
-  head: {
-    title: 'License',
-  },
-})
-export default class License extends Vue {}
+  }
+
+  head(): MetaInfo {
+    return {
+      title: 'License',
+      meta: [noindex],
+    }
+  }
+}
 </script>
 
 <style></style>

--- a/src/pages/search/index.vue
+++ b/src/pages/search/index.vue
@@ -9,6 +9,7 @@ import { MetaInfo } from 'vue-meta'
 import { SearchProp } from '~/models/vueProperties/searchPageProps'
 import SearchPage from '../../components/templates/SearchPage.vue'
 import { fullUrl } from '~/helpers/functions'
+import { noindex } from '~/helpers/globals'
 
 type PageUrl = { pageUrl: string }
 
@@ -45,6 +46,11 @@ export default class Search extends Vue {
           rel: 'canonical',
           href: this.$data.pageUrl,
         },
+      ],
+      meta: [
+        // canonical 属性がGoogleで期待通りの動作をしてくれないので
+        // 検索ページ自体の登録をブロック
+        noindex,
       ],
     }
   }


### PR DESCRIPTION
検索インデックスに登録したくないページについて、`noindex` メタタグを追加およびサイトマップからURL削除した。
またタグ検索ページへの `a` 要素によるリンクが存在すると検索インデックスに登録されてしまう可能性が増えるため、スクリプトによる遷移に変更した。

close #234