### PR TITLE
fix: fix paginations

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 import { join, resolve } from 'path'
+import { sortRoutes } from '@nuxt/utils'
 
 // <base> 要素の基準URIを設定
 const routerBase =
@@ -75,6 +76,7 @@ const conf = {
       '@/modules/asciidocPresenter',
       {
         source: 'outsides/asciidocs/source',
+        count: 10,
         processorOptions: {
           safe: 'server',
           template_dirs: [resolve(__dirname, 'src/helpers/asciidocTemplates')],
@@ -175,6 +177,17 @@ const conf = {
   router: {
     base: routerBase,
     trailingSlash: false,
+    extendRoutes(routes, resolve) {
+      routes.push({
+        name: 'page-id',
+        path: '/page/:id',
+        component: resolve(__dirname, 'src', 'pages/index.vue'),
+        meta: {},
+        children: [],
+      })
+
+      sortRoutes(routes)
+    },
   },
   /**
    * Generate route

--- a/src/components/organisms/Pagination.spec.ts
+++ b/src/components/organisms/Pagination.spec.ts
@@ -21,7 +21,7 @@ describe('Pagination', () => {
 
   test('is Vue', () => {
     const pages = [1, 2, 3, 4, 5, 6, 7, 8]
-    const wrapper = factory({ current: 3, pages })
+    const wrapper = factory({ current: 3, next: 4, prev: 2, pages })
 
     pages.forEach((x) =>
       expect(wrapper.find(`[data-action=move-${x}]`).exists()).toBeTruthy()
@@ -29,33 +29,72 @@ describe('Pagination', () => {
 
     expect(
       wrapper.find('[data-action=prev] nuxtlink-stub').attributes().to
-    ).toBe('/sample/hoge?page=2')
+    ).toBe('/sample/hoge/2')
 
     expect(
       wrapper.find('[data-action=next] nuxtlink-stub').attributes().to
-    ).toBe('/sample/hoge?page=4')
+    ).toBe('/sample/hoge/4')
+  })
+
+  test('disabled page', () => {
+    const pages = [1, 2, 3, 4, 5, 6, 7, 8]
+    const wrapper = factory({ current: 3, next: 4, prev: 2, pages })
+
+    expect(wrapper.findAll('[data-action^=move-]').length).toBe(pages.length)
+
+    //console.log(wrapper.find('[data-action=move-1] nuxtlink-stub').html())
+    expect(
+      wrapper.find('[data-action=move-3] nuxtlink-stub.disabled').exists()
+    ).toBe(true)
   })
 
   describe('pager method', () => {
-    const pager = Pagination.options.methods.pager
+    const wrapper = (page: number, path: string) =>
+      factory(
+        {
+          current: page,
+          next: page + 1,
+          prev: page - 1,
+          pages: [1, 2, 3, 4, 5, 6, 7],
+        },
+        path
+      )
 
-    test.each([
-      ['/hoge/foo', 1, '/hoge/foo?page=1'],
-      ['/hoge/foo?', 1, '/hoge/foo?page=1'],
-      ['/hoge/foo?tags=demo', 3, '/hoge/foo?tags=demo&page=3'],
-      ['/hoge/foo?page=2&tags=demo', 3, '/hoge/foo?tags=demo&page=3'],
-    ])('route: %s, page: %s', (path, page, result) => {
-      expect(pager(path, page)).toBe(result)
+    describe('default', () => {
+      test.each([
+        ['/hoge/foo', 1, '/hoge/foo/1'],
+        ['/hoge/foo?', 1, '/hoge/foo/1'],
+        ['/bar/foo?tags=demo', 3, '/bar/foo/3'],
+        ['/bar/foo?page=2&tags=demo', 3, '/bar/foo/3'],
+      ])('route: %s, page: %s', (path, page, result) => {
+        const elem = wrapper(page, path).find(
+          `[data-action=move-${page}] nuxtlink-stub`
+        )
+        expect(elem.attributes().to).toBe(result)
+        expect(elem.classes().includes('disabled')).toBeTruthy()
+      })
     })
 
-    test.each([
-      ['/bar?tags=vue nuxt.js', 2, '/bar?tags=vue+nuxt.js&page=2'],
-      ['/bar?tags=vue   nuxt.js', 2, '/bar?tags=vue+nuxt.js&page=2'],
-      ['/bar?tags=vue+nuxt.js', 2, '/bar?tags=vue+nuxt.js&page=2'],
-      ['/?tags=vue+nuxt.js', 4, '/?tags=vue+nuxt.js&page=4'],
-      ['?tags=vue+nuxt.js', 4, '?tags=vue+nuxt.js&page=4'],
-    ])('route: %s, page: %s', (path, page, result) => {
-      expect(pager(path, page)).toBe(result)
+    describe('query parameter', () => {
+      test.each([
+        ['/search', 1, '/search?page=1'],
+        ['/search?', 1, '/search?page=1'],
+        ['/search?tags=demo', 3, '/search?tags=demo&page=3'],
+        ['/search?page=2&tags=demo', 3, '/search?tags=demo&page=3'],
+        [
+          '/search/bar?tags=vue nuxt.js',
+          2,
+          '/search/bar?tags=vue+nuxt.js&page=2',
+        ],
+        ['/search/?tags=vue+nuxt.js', 4, '/search/?tags=vue+nuxt.js&page=4'],
+        ['/search?tags=vue+nuxt.js', 4, '/search?tags=vue+nuxt.js&page=4'],
+      ])('route: %s, page: %s', (path, page, result) => {
+        const elem = wrapper(page, path).find(
+          `[data-action=move-${page}] nuxtlink-stub`
+        )
+        expect(elem.attributes().to).toBe(result)
+        expect(elem.classes().includes('disabled')).toBeTruthy()
+      })
     })
   })
 })

--- a/src/components/templates/SearchPage.spec.ts
+++ b/src/components/templates/SearchPage.spec.ts
@@ -4,7 +4,7 @@ import SearchPage from './SearchPage.vue'
 
 describe('SearchPage', () => {
   function factory(
-    overviews?: { tags: string[] }[],
+    overviews?: readonly { tags: string[] }[],
     path = '/hoge/foo?page=2&tags=vue+nuxt.js'
   ) {
     const params = new URLSearchParams(path.split('?')[1])
@@ -21,7 +21,7 @@ describe('SearchPage', () => {
         $route: {
           fullPath: path,
           query: {
-            page: params.get('page'),
+            page: params.get('page') ?? -1,
             tags: params.get('tags'),
           },
         },
@@ -119,16 +119,20 @@ describe('SearchPage', () => {
   })
 
   describe('pageIndex', () => {
-    const views = new Array(41).fill({ tags: 'hoge' })
+    const views: ReadonlyArray<{ tags: string[] }> = new Array(41).fill({
+      tags: 'hoge',
+    })
 
     test.each([
-      ['/?page=1', 1, 3],
-      ['/?tags=foo&page=3', 1, 1],
+      ['/?page=1', 1, 5],
+      ['/?page=3', 3, 5],
+      ['/?tags=notfound-tag&page=3', 1, 1],
     ])('path: %s', (path, num, total) => {
       const w = factory(views, path)
       assertSeachPage(w.vm)
 
       const index = w.vm.pageIndex
+
       expect(index.num).toBe(num)
       expect(index.total).toBe(total)
     })

--- a/src/components/templates/SearchPage.vue
+++ b/src/components/templates/SearchPage.vue
@@ -20,8 +20,6 @@ import * as search from '~/models/vueProperties/searchPageProps'
 import { pagePostCount, postRoute } from '~/helpers/globals'
 import '~/helpers/string.extension'
 import TopPage from './TopPage.vue'
-import { NavigationGuard } from 'vue-router'
-import { ComponentOptions } from 'vue'
 import InputSearch from '../organisms/InputSearch.vue'
 
 @Component({

--- a/src/components/templates/TopPage.spec.ts
+++ b/src/components/templates/TopPage.spec.ts
@@ -83,6 +83,8 @@ describe('TopPage', () => {
     test('normal', () => {
       expect(pagerFactory(createProps())).toEqual({
         current: 2,
+        next: 3,
+        prev: 1,
         pages: [1, 2, 3, 4, 5, 6],
       })
     })
@@ -90,11 +92,11 @@ describe('TopPage', () => {
     test.each([
       [
         { num: 7, total: 2 },
-        { current: 2, pages: [1, 2] },
+        { current: 2, next: 2, prev: 1, pages: [1, 2] },
       ],
       [
         { num: -3, total: 5 },
-        { current: 1, pages: [1, 2, 3, 4, 5] },
+        { current: 1, next: 2, prev: 1, pages: [1, 2, 3, 4, 5] },
       ],
     ])('irregular', (obj, expected) => {
       expect(pagerFactory({ ...createProps(), pageIndex: obj })).toEqual(

--- a/src/components/templates/TopPage.vue
+++ b/src/components/templates/TopPage.vue
@@ -52,10 +52,17 @@ export default class TopPage
   }
 
   get pager(): Paging {
+    // 1 以上 total 以下の数値
+    const current = Math.min(
+      Math.max(this.pageIndex.num, 1),
+      this.pageIndex.total
+    )
+    const pages = [...new Array(this.pageIndex.total)].map((_, i) => i + 1)
     return {
-      // 1 以上 total 以下の数値
-      current: Math.min(Math.max(this.pageIndex.num, 1), this.pageIndex.total),
-      pages: [...new Array(this.pageIndex.total)].map((_, i) => i + 1),
+      next: Math.min(current + 1, this.pageIndex.total),
+      prev: Math.max(current - 1, 1),
+      current,
+      pages,
     }
   }
 }

--- a/src/helpers/globals.ts
+++ b/src/helpers/globals.ts
@@ -4,7 +4,7 @@
 export const postRoute = '/posts'
 
 /** 1ページあたりの記事の表示件数 */
-export const pagePostCount = 20
+export const pagePostCount = 10
 
 /** noindex メタタグ */
 export const noindex = { name: 'robots', content: 'noindex' }

--- a/src/models/paging.ts
+++ b/src/models/paging.ts
@@ -10,10 +10,12 @@ export interface PagingContent<T> {
 /**
  * ページング用の型。
  *
- * 現在ページと総ページ数を格納する。
+ * 現在ページ、次のページ、前のページおよび全てのページ番号を格納する。
  */
 export interface Paging {
   current: number
+  next: number
+  prev: number
   pages: number[]
 }
 


### PR DESCRIPTION
トップページおよび検索ページにおけるページネーションの動作を修正した。
トップページにおいてはページ送りするためにクエリパラメータを利用することを廃止し、URLパスの階層へと変更した。

またユーザーが記事の一覧を把握しやすくするため、1ページあたりの表示する記事を10件へと削減した。

close #236
