### PR TITLE
refactor: set meta info of head in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -183,7 +183,20 @@ const conf = {
           name: 'page-id',
           path: '/page/:id',
           component: resolve(__dirname, 'src', 'pages/index.vue'),
-          props: { noindex: true },
+          /** @return { { metaInfo: import('vue-meta').MetaInfo } } */
+          props: (route) => {
+            return {
+              metaInfo: {
+                title: `記事一覧 ${route.params.id}ページ目`,
+                meta: [
+                  // noindex
+                  { name: 'robots', content: 'noindex' },
+                  // canonical url
+                  { rel: 'canonical', href: '/' },
+                ],
+              },
+            }
+          },
         },
         {
           path: '/posts',

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -28,8 +28,8 @@ type PageUrl = { pageUrl: string }
 export default class Home extends Vue {
   pageIndex = { num: 1, total: 1 }
 
-  /** `noindex` メタタグの有無を判定するフラグ。 */
-  @Prop({ required: false, default: false }) noindex?: boolean
+  /** `<meta>` 要素を格納する。 */
+  @Prop({ required: false }) metaInfo?: MetaInfo
 
   get isFirstPage() {
     return this.pageIndex.num === 1
@@ -61,22 +61,18 @@ export default class Home extends Vue {
   }
 
   head(): MetaInfo {
-    const metaProperties: MetaInfo['meta'] = [
-      {
-        name: 'google-site-verification',
-        content: 'kvmP84hGKCFAytrygXPyfzJ_V9LGD0N2t4O8UVMBsBw',
-        hid: 'google-site-verification',
-      },
-    ]
-
-    if (this.noindex) {
-      metaProperties.push(noindex)
-    }
-
-    return {
-      title: 'Home',
-      meta: metaProperties,
-    }
+    return this.metaInfo != null
+      ? this.metaInfo
+      : {
+          title: 'Home',
+          meta: [
+            {
+              name: 'google-site-verification',
+              content: 'kvmP84hGKCFAytrygXPyfzJ_V9LGD0N2t4O8UVMBsBw',
+              hid: 'google-site-verification',
+            },
+          ],
+        }
   }
 }
 </script>


### PR DESCRIPTION
`extendRoutes` を利用して `noindex` フラグをコンポーネントに渡していたが、直接 `MetaInfo` オブジェクトを生成して渡すように変更した。