### PR TITLE
fix: add github environment

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,7 +80,10 @@ const conf = {
         processorOptions: {
           safe: 'server',
           template_dirs: [resolve(__dirname, 'src/helpers/asciidocTemplates')],
-          attributes: { 'env-nuxt': true, 'allow-uri-read': '' },
+          attributes: Object.assign(
+            { 'env-nuxt': true, 'allow-uri-read': '' },
+            process.env.GITHUB_ACTIONS === 'true' ? { 'env-github': true } : {}
+          ),
         },
       },
     ],


### PR DESCRIPTION
_Github Actions_ 上で実行した場合、_asciidoc_ 変換時に `env-github` 変数を追加するよう修正。