### PR TITLE
test: remove port on mermaid

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -55,8 +55,6 @@ jobs:
           - 8000:8000
       mermaid:
         image: yuzutech/kroki-mermaid
-        ports:
-          - 8002:8002
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
_Docker_ コンテナ同士ではポート公開せずとも通信ができるようなので、不必要なポートマッピング設定を削除した。