### PR TITLE
fix: limit container memory until 2.5gb

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -99,7 +99,12 @@
       "NOTES_ROOT": "/workspaces/notes"
     }
   },
-  "runArgs": ["--group-add=0"],
+  "runArgs": [
+    "--name=dev_vlife",
+    "--group-add=0",
+    "--memory=2560m",
+    "--memory-swap=2560m"
+  ],
   // Use a named volume for your entire source tree
   // https://code.visualstudio.com/docs/remote/containers-advanced#_use-a-named-volume-for-your-entire-source-tree
   "workspaceMount": "type=volume,src=vlife-blog,dst=/workspaces/vlife-blog",


### PR DESCRIPTION
コンテナが使用するメモリについて、2GB以上ないとビルドに失敗しやすく、3GB以上ではPC自体を逼迫する。
よって2.5GBまでに制限するよう修正。