### PR TITLE
fix: fix to highlight html entities by prismjs

### DIFF
--- a/src/plugins/prism.ts
+++ b/src/plugins/prism.ts
@@ -1,26 +1,27 @@
 import Vue from 'vue'
-import Prism from 'prismjs'
+import * as Prism from 'prismjs'
 //import 'prismjs/themes/prism-okaidia.css'
 import 'prism-themes/themes/prism-material-dark.css'
-import 'prismjs/plugins/line-numbers/prism-line-numbers'
+import 'prismjs/plugins/line-numbers/prism-line-numbers.min'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
-import 'prismjs/plugins/command-line/prism-command-line'
+import 'prismjs/plugins/command-line/prism-command-line.min'
 import 'prismjs/plugins/command-line/prism-command-line.css'
+import 'prismjs/plugins/keep-markup/prism-keep-markup.min'
 // languages
 //import 'prismjs/components/prism-core'
-import 'prismjs/components/prism-bash'
-import 'prismjs/components/prism-dart'
-import 'prismjs/components/prism-diff'
-import 'prismjs/components/prism-dns-zone-file'
-import 'prismjs/components/prism-docker'
-import 'prismjs/components/prism-git'
-import 'prismjs/components/prism-ini'
-import 'prismjs/components/prism-json'
-import 'prismjs/components/prism-powershell'
-import 'prismjs/components/prism-scss'
-import 'prismjs/components/prism-toml'
-import 'prismjs/components/prism-typescript'
-import 'prismjs/components/prism-yaml'
+import 'prismjs/components/prism-bash.min'
+import 'prismjs/components/prism-dart.min'
+import 'prismjs/components/prism-diff.min'
+import 'prismjs/components/prism-dns-zone-file.min'
+import 'prismjs/components/prism-docker.min'
+import 'prismjs/components/prism-git.min'
+import 'prismjs/components/prism-ini.min'
+import 'prismjs/components/prism-json.min'
+import 'prismjs/components/prism-powershell.min'
+import 'prismjs/components/prism-scss.min'
+import 'prismjs/components/prism-toml.min'
+import 'prismjs/components/prism-typescript.min'
+import 'prismjs/components/prism-yaml.min'
 
 interface PrismHighlight {
   /**
@@ -40,50 +41,15 @@ declare module 'vue/types/vue' {
 }
 
 /**
- * Prismによるハイライトを実行したときでも、AsciiDocのCalloutsタグをそのまま維持する `Prism.hooks` を追加する。
+ * Asciidoctor のコールアウトで生成されるHTMLタグにおいて、文字列を非表示にする（`.hidden` クラスを追加）。
+ *
+ * Keep Markupプラグインが実行される前のタイミングで処理させたいので、`before-sanity-check` とする。
  */
-function keepHighlight() {
-  // keep tags of callouts
-  const stashes = new Set<number>()
-  const placeholder = (id: number) => `___CALLOUTS_${id}___`
-  const token = (value: number) => `<i class="conum" data-value="${value}"></i>`
-
-  // AsciiDocのCalloutsタグを一時退避して、Prismjsによるサニタイズを回避する
-  // https://github.com/PrismJS/prism/issues/558
-  Prism.hooks.add('before-highlight', (env) => {
-    // callouts number regexp
-    const pattern = new RegExp(
-      `${token(0).replace('0', '(\\d+)')}<b>[^<]*</b>`,
-      'g'
-    )
-
-    if (!pattern.test(env.element.innerHTML)) {
-      return
-    }
-
-    const code = env.element.innerHTML.replace(pattern, (match, p1: number) => {
-      stashes.add(p1)
-      return placeholder(p1)
-    })
-
-    env.element.innerHTML = code
-    env.code = code
+Prism.hooks.add('before-sanity-check', (env) => {
+  env.element.querySelectorAll('.conum + b').forEach((elem) => {
+    elem.classList.add('hidden')
   })
-
-  // 一時退避したCalloutsタグをもとに戻す
-  Prism.hooks.add('after-highlight', (env) => {
-    stashes.forEach((id) => {
-      const code = env.highlightedCode.replace(
-        new RegExp(placeholder(id), 'g'),
-        token(id)
-      )
-
-      env.highlightedCode = code
-      env.element.innerHTML = code
-    })
-  })
-}
-keepHighlight()
+})
 
 // 実装
 Vue.prototype.$prism = {


### PR DESCRIPTION
`prism.js` によるシンタックスハイライト結果で不具合が発生していたのを修正した。

_Asciidoc_ のコールアウトを処理するために自作フックを作成していたが、これが原因でシンタックスハイライトの処理に不具合が発生していた。
これをコールアウトのHTMLタグは _Keep Markup_ プラグインを使って残すように変更した。
またこのままではハイライト処理によりコールアウトのHTML要素の構造が変化してCSSでの対処が難しくなるため、フックによって数値テキストを表示させない（`.hidden`）ようにした。