### PR TITLE
refactor: build outputs to the pre-release branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -98,7 +98,8 @@ jobs:
         if: ${{ !env.ACT }}
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: deploy
+          publish_branch: pre-release
           publish_dir: ./dist
+          force_orphan: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
ビルドしたWebサイトを公開前に確認できるようにするため、
確認用ブランチにデプロイするようにフローを修正した。

close #281