### PR TITLE
chore(deps): revert #310 follow-redirects

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,9 +5720,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
_AsciiDoc_ 本文中のダイアグラム図を描画する `svg` コードが消えてしまったため差し戻し。

This reverts commit 17ee853849a77286cf61aecaf8da4485917b068f, reversing changes made to f80395c80aecb9dce64ab41eee4bed6345adbaac.