### PR TITLE
fix: remove minify configs

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -194,17 +194,6 @@ const conf = {
     },
 
     transpile: ['vee-validate/dist/rules'],
-    // Nuxt minify config: https://nuxtjs.org/docs/configuration-glossary/configuration-build/#html-minify
-    html: {
-      minify: {
-        collapseWhitespace: true,
-        minifyCSS: false,
-        minifyJS: false,
-        preserveLineBreaks: true,
-        removeComments: true,
-        removeEmptyAttributes: true
-      },
-    },
   },
   /*
    ** Router


### PR DESCRIPTION
_search.html_ が期待通りの動作をしなくなったため修正。

- 結局は `js-beautify` で整形するため、無駄になる `minify` 設定を削除。