### PR TITLE
refactor: format json files

### DIFF
--- a/src/components/templates/ArticlePosted.spec.ts
+++ b/src/components/templates/ArticlePosted.spec.ts
@@ -15,7 +15,7 @@ describe('ArticlePosted', () => {
       updated_at: '2020-04-29',
       author: 'akiakiS',
       description: 'sample text source.',
-      rendered: '<div>hoge</div>',
+      rendered: ['<div>hoge</div>'],
       revision: '1.2',
       revision_remark: 'Change to asciidoc',
     }

--- a/src/components/templates/ArticlePosted.vue
+++ b/src/components/templates/ArticlePosted.vue
@@ -167,17 +167,17 @@ export default class ArticlePosted
 
     // ページ内遷移
     const hashPattern = new RegExp('(<a [^>]*href=")(#[^"]*)("[^>]*>)', 'g')
-    const ast = this.posted.rendered.replace(
+    const ast = this.posted.rendered.map(line => line.replace(
       hashPattern,
       `$1${new URL(this.currentFullPath).pathname}$2$3`
-    )
+    ))
 
     // サイト内遷移
     const internal = new RegExp(
       '(<a [^>]*href=")([^/][^:]+/[^"]*)("[^>]*>)',
       'g'
     )
-    const body = ast.replace(internal, `$1${parent}/$2$3`)
+    const body = ast.join('\n').replace(internal, `$1${parent}/$2$3`)
 
     return body
   }

--- a/src/modules/asciidocPresenter/index.d.ts
+++ b/src/modules/asciidocPresenter/index.d.ts
@@ -53,7 +53,7 @@ export interface AsciidocSummaryJson {
  * @param {?string} revision_remark 更新内容
  */
 export interface AsciidocParsed extends AsciidocSummary {
-  rendered: string // '<div>...</div>'
+  rendered: string[] // '[<div class="hoge1">...</div>, <div class="hoge2">...</div>]'
   title?: string | import('@asciidoctor/core').Asciidoctor.Document.Title // 'Asciidoc Document Title'
   tags: string[] // '["sample", "test"] (convert from tags attribute)'
   updated_at?: string // '2020-08-10 (revision date)'

--- a/src/modules/asciidocPresenter/test/asciidoc.spec.ts
+++ b/src/modules/asciidocPresenter/test/asciidoc.spec.ts
@@ -25,7 +25,8 @@ hogehoge`
 :tags: foo,bar
 :created_at: 2020-08-15
 == Obon
-Wacchoi!`
+Wacchoi!
+IYA!`
       )
       .set(
         'sample03.adoc',
@@ -48,7 +49,7 @@ v1.2,2020-08-12
     const expected: AsciidocParsed = {
       filename: path.basename(file),
       created_at: doc.getAttribute('created_at'),
-      rendered: doc.convert(),
+      rendered: doc.convert().split(/\n/),
       tags: (doc.getAttribute('tags') + '').split(',').map((x) => x.trim()),
       title: doc.getDocumentTitle(),
       author: doc.getAttribute('author'),
@@ -89,7 +90,7 @@ v1.2,2020-08-12
     const expected = { filename: 'path/to/hoge', created_at: '2020-08-14' }
     const input: AsciidocParsed = {
       ...expected,
-      rendered: '<div>hello</div>',
+      rendered: ['<div>hello</div>'],
       tags: ['test', 'sample'],
       title: 'Sample Title',
       author: 'akiakiS',

--- a/src/modules/asciidocPresenter/utils/asciidoc.js
+++ b/src/modules/asciidocPresenter/utils/asciidoc.js
@@ -51,7 +51,7 @@ export function parse(file, options) {
   /** @type {import('..').AsciidocParsed} */
   const parsing = {
     filename: basename(file),
-    rendered: doc.convert(),
+    rendered: doc.convert().split(/\n/),
     title: doc.getDocumentTitle(),
     created_at: doc.getAttribute('created_at'),
     tags: (doc.getAttribute('tags') + '')

--- a/src/modules/asciidocPresenter/utils/webpack.js
+++ b/src/modules/asciidocPresenter/utils/webpack.js
@@ -46,7 +46,7 @@ export function createPlugin(contents, count, api) {
          * @param {Record<string, any>} obj オブジェクトデータ
          */
         const addAssets = (name, obj) => {
-          const data = JSON.stringify(obj)
+          const data = JSON.stringify(obj, undefined, 2)  // スペース2個のインデント
           compilation.assets[name] = {
             source: () => data,
             size: () => data.length,


### PR DESCRIPTION
記事の内容を書き出す _JSON_ ファイルをフォーマットしておき、_git_ 管理をしやすくする。

#320 