### PR TITLE
refactor: fix the generated static directory name

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -257,6 +257,11 @@ const conf = {
   generate: {
     fallback: true,
     subFolders: false,
+    // https://github.com/nuxt/nuxt/blob/d4b9e4b0553bcd617ecbc0b8b76871070b347fcb/packages/generator/src/generator.js#L33
+    staticAssets: {
+      // nuxt generate 時に生成される静的ディレクトリ名を固定する
+      version: '2023013021',
+    },
   },
   /*
    ** Nuxt source directory


### PR DESCRIPTION
`nuxt generate` 時に生成される静的ディレクトリ名を固定化する。
固定することでサイト更新時に不要なファイル変更が検出されることを防ぐ。

link #320