### PR TITLE
ci: deprecate set-output and save-state commands

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,7 +40,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       ### Git Submodule
@@ -67,10 +67,10 @@ jobs:
       ### Cache
       - name: get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: cache dependencies
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.2.5
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,22 +19,22 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: set cachedir of yarn
         id: cachedir
-        run: echo "::set-output name=path::$(yarn cache dir)"
+        run: echo "path=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: set cache key
         id: cachekey
-        run: echo "::set-output name=key::$CACHE_KEY"
+        run: echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
         env:
           CACHE_KEY: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: caches
-        # https://github.com/actions/cache/tree/v2.1.4
-        uses: actions/cache@v2.1.4
+        # https://github.com/actions/cache/tree/v3.2.5
+        uses: actions/cache@v3.2.5
         id: cache-action
         with:
           path: ${{ steps.cachedir.outputs.path }}
@@ -63,11 +63,11 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: use caches
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.2.5
         id: cache-action
         with:
           path: ${{ needs.yarn_cache.outputs.cachedir }}

--- a/.github/workflows/testing_pull_request.yml
+++ b/.github/workflows/testing_pull_request.yml
@@ -19,15 +19,15 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: cache dependencies
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.2.5
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
_Github Workflow_ にて、`set-output` と `save-state` コマンドが廃止予定になっていたので、環境変数を用いる方法に変更および `actions/cache` のバージョンアップを行った。
また、`actions/cache` のバージョンアップに伴い、`nodejs` も `16` へとバージョンアップした。

refs: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/